### PR TITLE
Scroll to top on page navigation

### DIFF
--- a/frontend/antrakt/src/App.tsx
+++ b/frontend/antrakt/src/App.tsx
@@ -36,6 +36,7 @@ import DirectorDetail from "./pages/cards/DirectorDetail";
 import AchievementDetail from "./pages/cards/AchievementDetail";
 import PerformanceDetail from "./pages/cards/PerfomancesDetail";
 import ProfilePage from "./pages/ProfilePage";
+import ScrollToTop from "./components/ScrollToTop";
 
 // Главная страница сайта
 const MainPage = () => (
@@ -81,6 +82,7 @@ function App() {
     <BrowserRouter>
       <ChakraProvider theme={theme}>
         <AuthProvider>
+          <ScrollToTop />
           <Routes>
             {/* Главная страница */}
             <Route path="/" element={<MainPage />} />

--- a/frontend/antrakt/src/components/ScrollToTop.tsx
+++ b/frontend/antrakt/src/components/ScrollToTop.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // Прокручиваем к началу страницы при изменении маршрута
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
Add `ScrollToTop` component to ensure pages always open at the top on navigation.

This component uses `react-router-dom`'s `useLocation` hook to detect route changes and automatically scrolls the window to the top (`0,0`) whenever the pathname changes. This resolves the issue where pages would retain the scroll position from the previous page.

---

[Open in Web](https://www.cursor.com/agents?id=bc-fae3ad59-5f5e-43d9-9f25-40a8f90150de) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fae3ad59-5f5e-43d9-9f25-40a8f90150de)