### PR TITLE
Исправить перенаправление на страницах сущностей

### DIFF
--- a/frontend/antrakt/src/components/Footer.tsx
+++ b/frontend/antrakt/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Text, Link, Grid, GridItem, Heading, Icon, chakra } from "@chakra-ui/react";
 import { motion } from "framer-motion";
+import { Link as RouterLink } from "react-router-dom";
 import {
     FaVk,
     FaTelegram,
@@ -11,7 +12,6 @@ import {
     FaClock
 } from "react-icons/fa";
 import type { ComponentWithAs, IconProps } from "@chakra-ui/react";
-import { url } from "inspector";
 
 const MotionBox = motion(Box);
 const MotionLink = motion(Link);
@@ -187,7 +187,8 @@ export default function Footer() {
                             {navLinks.map((link, index) => (
                                 <MotionLink
                                     key={index}
-                                    href={link.url}
+                                    as={RouterLink}
+                                    to={`/${link.url}`}
                                     color={grayText}
                                     fontSize="md"
                                     mb={2}

--- a/frontend/antrakt/src/components/Navigation.tsx
+++ b/frontend/antrakt/src/components/Navigation.tsx
@@ -18,7 +18,7 @@ import {
 } from "@chakra-ui/react";
 import { CloseIcon, HamburgerIcon } from "@chakra-ui/icons";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom"; // Добавлен импорт useNavigate
+import { useNavigate, Link as RouterLink } from "react-router-dom"; // Добавлен импорт Link as RouterLink
 import AuthModal from "./AuthModal";
 import { useAuth } from "../contexts/AuthContext";
 
@@ -137,7 +137,7 @@ export default function Navigation() {
                 py={4}
             >
                 <Box>
-                    <Link href="/" _hover={{ textDecoration: "none" }}>
+                    <Link as={RouterLink} to="/" _hover={{ textDecoration: "none" }}>
                         <Text fontSize="xl" fontWeight="bold" color={lightText} letterSpacing="wide">
                             ТЕАТР СТУДИЯ <Text as="span" color={primaryColor}>АНТРАКТ</Text>
                         </Text>
@@ -148,7 +148,8 @@ export default function Navigation() {
                     {NAV_ITEMS.map((item) => (
                         <Link
                             key={item.label}
-                            href={item.href}
+                            as={RouterLink}
+                            to={`/${item.href}`}
                             color={lightText}
                             fontWeight={500}
                             _hover={{ textDecoration: "none", color: primaryColor, transform: "translateY(-2px)" }}
@@ -230,7 +231,8 @@ export default function Navigation() {
                         {NAV_ITEMS.map((item) => (
                             <Link
                                 key={item.label}
-                                href={item.href}
+                                as={RouterLink}
+                                to={`/${item.href}`}
                                 color={lightText}
                                 py={2}
                                 px={4}


### PR DESCRIPTION
Fixes incorrect relative path navigation by replacing HTML `<a>` tags with `react-router-dom`'s `Link` component in navigation elements.

When navigating from a specific detail page (e.g., `/performance/2`), clicking a link with a relative `href` (e.g., "about") would incorrectly resolve to `/performance/2/about` instead of `/about`. This was caused by standard `<a>` tags performing full page reloads and resolving relative paths against the current URL. Using `react-router-dom`'s `Link` ensures correct root-relative navigation.

---

[Open in Web](https://cursor.com/agents?id=bc-de665006-df5c-4cbd-95e9-9eb3d3d9b87f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-de665006-df5c-4cbd-95e9-9eb3d3d9b87f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)