### PR TITLE
Fix database initialization with init.sql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       - "5432:5432"
     networks:
       - antrakt_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d antrakt"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   # MinIO Object Storage Service
@@ -64,6 +70,8 @@ services:
     networks:
       - antrakt_network
     depends_on:
+      postgres:
+        condition: service_healthy
       minio:
         condition: service_healthy
     command: >

--- a/rebuild_with_fresh_db.sh
+++ b/rebuild_with_fresh_db.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "Останавливаем все контейнеры..."
+docker-compose down
+
+echo "Удаляем volume с данными PostgreSQL для полной очистки..."
+docker volume rm $(docker-compose config --volumes | grep postgres_data) 2>/dev/null || echo "Volume postgres_data не найден или уже удален"
+
+echo "Пересобираем образы..."
+docker-compose build --no-cache
+
+echo "Запускаем сервисы..."
+docker-compose up -d
+
+echo "Проверяем статус сервисов..."
+docker-compose ps
+
+echo "Готово! База данных будет инициализирована из init.sql"
+echo "Для просмотра логов используйте: docker-compose logs -f postgres"


### PR DESCRIPTION
Ensure PostgreSQL database is initialized from `init.sql` on `docker-compose up` by adding a healthcheck and updating service dependencies.

The `backend` service was starting before the `postgres` container had finished executing the `init.sql` script. By adding a `healthcheck` to the `postgres` service and making the `backend` service `depends_on` the `postgres` service being `healthy`, we guarantee that the `backend` only starts once the database is fully initialized and populated. A `rebuild_with_fresh_db.sh` script was also added for convenient full rebuilds.

---
<a href="https://cursor.com/background-agent?bcId=bc-42f35ad7-7012-41f1-8152-797f0533e9d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42f35ad7-7012-41f1-8152-797f0533e9d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>