### PR TITLE
Fix docker compose viah warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ POSTGRES_PORT=5432
 
 # Настройки Django
 DEBUG=False
-SECRET_KEY=django-insecure-tz-^0_e%qv2&ac4e1$viah-tr=gby9=0grcdeu_yp0kcop^_1%
+SECRET_KEY=django-insecure-tz-^0_e%qv2&ac4e1$$viah-tr=gby9=0grcdeu_yp0kcop^_1%
 ALLOWED_HOSTS=localhost
 
 # Настройки MinIO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15


### PR DESCRIPTION
Fix Docker Compose warnings by escaping `$` in `SECRET_KEY` and removing obsolete `version` attribute.

The `SECRET_KEY` contained an unescaped `$` character, causing Docker Compose to incorrectly interpret a substring as an undefined environment variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-527417f7-d70c-4c39-a440-e65a3981c935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-527417f7-d70c-4c39-a440-e65a3981c935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>