### PR TITLE
Исправить проверку запуска minio и postgres

### DIFF
--- a/backend/app/app/settings.py
+++ b/backend/app/app/settings.py
@@ -122,54 +122,25 @@ AUTH_USER_MODEL = 'my_app1.User'
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-# Проверяем доступность PostgreSQL
-import socket
-import sys
-
-def is_service_available(host, port):
-    """Проверяет доступность сервиса"""
-    try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(1)
-        result = sock.connect_ex((host, int(port)))
-        sock.close()
-        return result == 0
-    except:
-        return False
-
-# Получаем настройки БД
+# Настройки БД
 db_host = config('DATABASE_HOST', default='localhost')
 db_port = config('DATABASE_PORT', default='5432')
 db_name = config('DATABASE_NAME', default='antrakt')
 db_user = config('DATABASE_USER', default='postgres')
 db_password = config('DATABASE_PASSWORD', default='123')
 
-# Проверяем доступность PostgreSQL
-postgres_available = is_service_available(db_host, db_port)
-
-if postgres_available:
-    # Используем PostgreSQL если доступен
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': db_name,
-            'USER': db_user,
-            'PASSWORD': db_password,
-            'HOST': db_host,
-            'PORT': db_port,
-        }
+# Используем PostgreSQL
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': db_name,
+        'USER': db_user,
+        'PASSWORD': db_password,
+        'HOST': db_host,
+        'PORT': db_port,
     }
-    print(f"✓ Используется PostgreSQL: {db_host}:{db_port}")
-else:
-    # Fallback на SQLite если PostgreSQL недоступен
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': BASE_DIR / 'db.sqlite3',
-        }
-    }
-    print("⚠ PostgreSQL недоступен, используется SQLite")
-    print(f"  Проверьте подключение к {db_host}:{db_port}")
+}
+print(f"✓ Используется PostgreSQL: {db_host}:{db_port}")
 
 
 # Password validation
@@ -219,17 +190,9 @@ MINIO_ACCESS_KEY = config('MINIO_ACCESS_KEY', default='minioadmin')
 MINIO_SECRET_KEY = config('MINIO_SECRET_KEY', default='minioadmin123')
 MINIO_BUCKET_NAME = config('MINIO_BUCKET_NAME', default='antrakt-images')
 
-# Проверяем доступность MinIO
-minio_host, minio_port = MINIO_ENDPOINT.split(':')
-minio_available = is_service_available(minio_host, minio_port)
-
-if minio_available:
-    print(f"✓ MinIO доступен: {MINIO_ENDPOINT}")
-    USE_MINIO = True
-else:
-    print(f"⚠ MinIO недоступен: {MINIO_ENDPOINT}")
-    print("  Будет использоваться локальное хранение файлов")
-    USE_MINIO = False
+# Используем MinIO
+USE_MINIO = True
+print(f"✓ MinIO настроен: {MINIO_ENDPOINT}")
 
 # Development settings
 if os.name == 'nt':  # Windows development

--- a/backend/app/my_app1/minio_utils.py
+++ b/backend/app/my_app1/minio_utils.py
@@ -115,12 +115,12 @@ def get_minio_client():
     global _minio_client
     if _minio_client is None:
         from django.conf import settings
-        # Проверяем, доступен ли MinIO
+        # Используем MinIO если включен в настройках
         if getattr(settings, 'USE_MINIO', False):
             try:
                 _minio_client = MinioClient()
             except Exception as e:
-                print(f"Не удалось инициализировать MinIO клиент: {e}")
+                print(f"Ошибка инициализации MinIO клиента: {e}")
                 _minio_client = False  # Помечаем как недоступный
         else:
             _minio_client = False  # MinIO отключен
@@ -136,7 +136,7 @@ def upload_image_to_minio(image_file, folder="images"):
         folder: Папка для сохранения
         
     Returns:
-        str: URL загруженного изображения или None если MinIO недоступен
+        str: URL загруженного изображения или None если MinIO не настроен
     """
     client = get_minio_client()
     if client:
@@ -147,7 +147,7 @@ def upload_image_to_minio(image_file, folder="images"):
             print("Переключение на локальное хранение")
             return None
     else:
-        print("MinIO недоступен, используется локальное хранение")
+        print("MinIO не настроен, используется локальное хранение")
         return None
 
 
@@ -162,4 +162,4 @@ def delete_image_from_minio(image_url):
     if client:
         client.delete_file(image_url)
     else:
-        print("MinIO недоступен, удаление из локального хранения не требуется")
+        print("MinIO не настроен, удаление из локального хранения не требуется")

--- a/backend/app/my_app1/views.py
+++ b/backend/app/my_app1/views.py
@@ -644,7 +644,7 @@ class ImageUploadView(APIView):
                 return Response({
                     'success': True,
                     'image_url': local_url,
-                    'message': 'Изображение сохранено локально (MinIO недоступен)',
+                    'message': 'Изображение сохранено локально',
                     'storage_type': 'local'
                 }, status=status.HTTP_201_CREATED)
             


### PR DESCRIPTION
Removes MinIO and PostgreSQL startup availability checks to prevent false negatives and updates related messages.

The previous checks used a short timeout, leading to misleading 'service unavailable' messages even when services were functional. This change ensures the backend directly attempts to use the services without pre-validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-36d3c6f5-788e-49e5-9b10-7b3e709e35a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36d3c6f5-788e-49e5-9b10-7b3e709e35a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

