### PR TITLE
Исправить проверку запуска minio и postgres

### DIFF
--- a/backend/app/app/settings.py
+++ b/backend/app/app/settings.py
@@ -122,21 +122,6 @@ AUTH_USER_MODEL = 'my_app1.User'
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-# Проверяем доступность PostgreSQL
-import socket
-import sys
-
-def is_service_available(host, port):
-    """Проверяет доступность сервиса"""
-    try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(1)
-        result = sock.connect_ex((host, int(port)))
-        sock.close()
-        return result == 0
-    except:
-        return False
-
 # Получаем настройки БД
 db_host = config('DATABASE_HOST', default='localhost')
 db_port = config('DATABASE_PORT', default='5432')
@@ -144,33 +129,18 @@ db_name = config('DATABASE_NAME', default='antrakt')
 db_user = config('DATABASE_USER', default='postgres')
 db_password = config('DATABASE_PASSWORD', default='123')
 
-# Проверяем доступность PostgreSQL
-postgres_available = is_service_available(db_host, db_port)
-
-if postgres_available:
-    # Используем PostgreSQL если доступен
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': db_name,
-            'USER': db_user,
-            'PASSWORD': db_password,
-            'HOST': db_host,
-            'PORT': db_port,
-        }
+# Используем PostgreSQL без предварительной проверки доступности
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': db_name,
+        'USER': db_user,
+        'PASSWORD': db_password,
+        'HOST': db_host,
+        'PORT': db_port,
     }
-    print(f"✓ Используется PostgreSQL: {db_host}:{db_port}")
-else:
-    # Fallback на SQLite если PostgreSQL недоступен
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': BASE_DIR / 'db.sqlite3',
-        }
-    }
-    print("⚠ PostgreSQL недоступен, используется SQLite")
-    print(f"  Проверьте подключение к {db_host}:{db_port}")
-
+}
+print(f"✓ Настроена конфигурация PostgreSQL: {db_host}:{db_port}")
 
 # Password validation
 # https://docs.djangoproject.com/en/5.2/ref/settings/#auth-password-validators
@@ -219,17 +189,9 @@ MINIO_ACCESS_KEY = config('MINIO_ACCESS_KEY', default='minioadmin')
 MINIO_SECRET_KEY = config('MINIO_SECRET_KEY', default='minioadmin123')
 MINIO_BUCKET_NAME = config('MINIO_BUCKET_NAME', default='antrakt-images')
 
-# Проверяем доступность MinIO
-minio_host, minio_port = MINIO_ENDPOINT.split(':')
-minio_available = is_service_available(minio_host, minio_port)
-
-if minio_available:
-    print(f"✓ MinIO доступен: {MINIO_ENDPOINT}")
-    USE_MINIO = True
-else:
-    print(f"⚠ MinIO недоступен: {MINIO_ENDPOINT}")
-    print("  Будет использоваться локальное хранение файлов")
-    USE_MINIO = False
+# Включаем MinIO без предварительной проверки доступности
+USE_MINIO = True
+print(f"✓ Настроена конфигурация MinIO: {MINIO_ENDPOINT}")
 
 # Development settings
 if os.name == 'nt':  # Windows development
@@ -249,9 +211,4 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 
 # Настройки для работы с разными типами БД
-if 'sqlite' in DATABASES['default']['ENGINE']:
-    # Для SQLite отключаем некоторые PostgreSQL-специфичные настройки
-    print("⚠ Используется SQLite - некоторые PostgreSQL функции недоступны")
-    # Убираем django.contrib.postgres из INSTALLED_APPS если используется SQLite
-    if 'django.contrib.postgres' in INSTALLED_APPS:
-        INSTALLED_APPS = [app for app in INSTALLED_APPS if app != 'django.contrib.postgres']
+print("✓ Используется PostgreSQL с полной функциональностью")

--- a/backend/app/my_app1/minio_utils.py
+++ b/backend/app/my_app1/minio_utils.py
@@ -114,16 +114,15 @@ def get_minio_client():
     """Получает экземпляр MinIO клиента с ленивой инициализацией"""
     global _minio_client
     if _minio_client is None:
-        from django.conf import settings
-        # Проверяем, доступен ли MinIO
-        if getattr(settings, 'USE_MINIO', False):
-            try:
-                _minio_client = MinioClient()
-            except Exception as e:
-                print(f"Не удалось инициализировать MinIO клиент: {e}")
-                _minio_client = False  # Помечаем как недоступный
-        else:
-            _minio_client = False  # MinIO отключен
+        try:
+            _minio_client = MinioClient()
+            # Тестируем соединение, попробовав проверить существование bucket
+            _minio_client.client.bucket_exists(_minio_client.bucket_name)
+            print(f"✓ MinIO клиент успешно инициализирован: {_minio_client.client._base_url}")
+        except Exception as e:
+            print(f"⚠ Не удалось подключиться к MinIO: {e}")
+            print("  Будет использоваться локальное хранение файлов")
+            _minio_client = False  # Помечаем как недоступный
     return _minio_client if _minio_client is not False else None
 
 


### PR DESCRIPTION
Remove unreliable pre-flight service checks for PostgreSQL and MinIO, and improve MinIO connection verification.

The previous socket-based checks for PostgreSQL and MinIO were prone to false negatives, especially for MinIO running in Docker, leading to incorrect "MinIO недоступен" messages. This change removes these problematic checks and instead relies on Django's standard database connection handling and a more robust MinIO API call to verify connectivity, ensuring a cleaner and more accurate startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-09a2749d-2ddd-4869-80f9-c0a2449623c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09a2749d-2ddd-4869-80f9-c0a2449623c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

