### PR TITLE
Fix image upload to minio

### DIFF
--- a/backend/app/app/settings.py
+++ b/backend/app/app/settings.py
@@ -212,3 +212,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 
 # Настройки для работы с разными типами БД
 print("✓ Используется PostgreSQL с полной функциональностью")
+
+# MinIO endpoints for internal SDK access and public URL generation
+MINIO_INTERNAL_ENDPOINT = config('MINIO_INTERNAL_ENDPOINT', default=MINIO_ENDPOINT)
+MINIO_PUBLIC_ENDPOINT = config('MINIO_PUBLIC_ENDPOINT', default='localhost:9000')


### PR DESCRIPTION
Fix MinIO image upload by separating internal/public endpoints, ensuring public-read policy, and improving stream handling.

Previously, MinIO uploads failed due to the SDK using the same endpoint for internal communication and public URL generation, a missing public-read policy on the bucket, and issues with handling file stream lengths during upload. This PR introduces distinct internal and public MinIO endpoints in Django settings, ensures the `antrakt-images` bucket has a public-read policy, and makes the `put_object` call more robust by correctly handling stream positions and lengths.

---
<a href="https://cursor.com/background-agent?bcId=bc-70a5e903-cafd-4229-9c4a-8b5e644a2828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70a5e903-cafd-4229-9c4a-8b5e644a2828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

