### PR TITLE
Configure minio for photo storage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,22 @@
+# Django
+DEBUG=True
+SECRET_KEY=changeme-in-prod
+
+# Database
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_NAME=antrakt
+DATABASE_USER=postgres
+DATABASE_PASSWORD=123
+
+# MinIO / S3
+USE_MINIO_STORAGE=True
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin123
+MINIO_BUCKET_NAME=antrakt-media
+# If backend runs outside docker, keep localhost; if inside same docker network, use http://minio:9000
+MINIO_ENDPOINT=http://localhost:9000
+MINIO_REGION=us-east-1
+MINIO_URL_PROTOCOL=http:
+# Optional override (otherwise computed as <endpoint-host>/<bucket>)
+# MINIO_CUSTOM_DOMAIN=localhost:9000/antrakt-media

--- a/backend/app/.env.example
+++ b/backend/app/.env.example
@@ -1,0 +1,22 @@
+# Django
+DEBUG=True
+SECRET_KEY=changeme-in-prod
+
+# Database
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_NAME=antrakt
+DATABASE_USER=postgres
+DATABASE_PASSWORD=123
+
+# MinIO / S3
+USE_MINIO_STORAGE=True
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin123
+MINIO_BUCKET_NAME=antrakt-media
+# If backend runs outside docker, keep localhost; if inside same docker network, use http://minio:9000
+MINIO_ENDPOINT=http://localhost:9000
+MINIO_REGION=us-east-1
+MINIO_URL_PROTOCOL=http:
+# Optional override (otherwise computed as <endpoint-host>/<bucket>)
+# MINIO_CUSTOM_DOMAIN=localhost:9000/antrakt-media

--- a/backend/app/app/urls.py
+++ b/backend/app/app/urls.py
@@ -71,5 +71,7 @@ urlpatterns = [
     path('achievement<int:id>/', views.AchievementDetail.as_view(), name="achievement"),
     path('achievements-admin/', views.AchievementListAdmin.as_view(), name='achievement-list-admin'),
     path('afisha/', views.AfishaList.as_view(), name='afisha-list'),
+    path('upload-image/', views.ImageUploadView.as_view(), name='upload-image'),
+    path('delete-image/', views.ImageDeleteView.as_view(), name='delete-image'),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name="schema-swagger-ui"),
 ]

--- a/backend/app/my_app1/apps.py
+++ b/backend/app/my_app1/apps.py
@@ -4,3 +4,44 @@ from django.apps import AppConfig
 class MyApp1Config(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'my_app1'
+
+    def ready(self):
+        # Lazily create the bucket on startup if using MinIO storage
+        from django.conf import settings
+        if getattr(settings, 'USE_MINIO_STORAGE', False):
+            try:
+                import boto3
+                from botocore.exceptions import ClientError
+
+                s3_client = boto3.client(
+                    's3',
+                    endpoint_url=settings.AWS_S3_ENDPOINT_URL,
+                    aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                    aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                    region_name=settings.AWS_S3_REGION_NAME,
+                )
+                bucket = settings.AWS_STORAGE_BUCKET_NAME
+                try:
+                    s3_client.head_bucket(Bucket=bucket)
+                except ClientError:
+                    s3_client.create_bucket(Bucket=bucket)
+                    # Make objects publicly readable by default via bucket policy
+                    public_policy = {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Sid": "PublicReadGetObject",
+                                "Effect": "Allow",
+                                "Principal": "*",
+                                "Action": ["s3:GetObject"],
+                                "Resource": [f"arn:aws:s3:::{bucket}/*"]
+                            }
+                        ]
+                    }
+                    s3_client.put_bucket_policy(
+                        Bucket=bucket,
+                        Policy=__import__('json').dumps(public_policy)
+                    )
+            except Exception:
+                # Fail silently to not block app startup in dev
+                pass


### PR DESCRIPTION
Integrate MinIO for photo storage in the Django backend, including upload/delete endpoints and automatic bucket setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd6c3c06-a951-4cfb-ba10-9ae7f59d0104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd6c3c06-a951-4cfb-ba10-9ae7f59d0104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

