### PR TITLE
Fix proxy connection error on image upload

### DIFF
--- a/backend/app/app/settings.py
+++ b/backend/app/app/settings.py
@@ -224,6 +224,19 @@ if USE_MINIO_STORAGE:
         default=f"{_endpoint_no_scheme}/{AWS_STORAGE_BUCKET_NAME}"
     )
 
+    # Ensure local MinIO host is excluded from proxies to avoid ProxyConnectionError
+    try:
+        from urllib.parse import urlparse as _urlparse
+        _parsed = _urlparse(AWS_S3_ENDPOINT_URL)
+        _hostport = _parsed.netloc
+        _existing_no_proxy = os.environ.get('NO_PROXY', os.environ.get('no_proxy', ''))
+        if _hostport and _hostport not in _existing_no_proxy:
+            _combined = (_existing_no_proxy + ',' if _existing_no_proxy else '') + _hostport
+            os.environ['NO_PROXY'] = _combined
+            os.environ['no_proxy'] = _combined
+    except Exception:
+        pass
+
     # Use S3-backed storage for Django file storage
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 

--- a/backend/app/my_app1/apps.py
+++ b/backend/app/my_app1/apps.py
@@ -12,6 +12,7 @@ class MyApp1Config(AppConfig):
             try:
                 import boto3
                 from botocore.exceptions import ClientError
+                from botocore.client import Config as BotoConfig
 
                 s3_client = boto3.client(
                     's3',
@@ -19,6 +20,7 @@ class MyApp1Config(AppConfig):
                     aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
                     aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
                     region_name=settings.AWS_S3_REGION_NAME,
+                    config=BotoConfig(proxies={})
                 )
                 bucket = settings.AWS_STORAGE_BUCKET_NAME
                 try:

--- a/backend/app/my_app1/views.py
+++ b/backend/app/my_app1/views.py
@@ -601,7 +601,7 @@ class ImageUploadView(APIView):
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
             region_name=settings.AWS_S3_REGION_NAME,
-            config=BotoConfig(signature_version='s3v4')
+            config=BotoConfig(signature_version='s3v4', proxies={})
         )
         bucket = settings.AWS_STORAGE_BUCKET_NAME
         extension = image.name.split('.')[-1].lower()
@@ -646,7 +646,7 @@ class ImageDeleteView(APIView):
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
             region_name=settings.AWS_S3_REGION_NAME,
-            config=BotoConfig(signature_version='s3v4')
+            config=BotoConfig(signature_version='s3v4', proxies={})
         )
 
         try:


### PR DESCRIPTION
Disable proxy usage for S3 clients and add the MinIO endpoint to `NO_PROXY` to resolve `ProxyConnectionError` during image uploads.

The `ProxyConnectionError` occurred because `boto3` was attempting to connect to a local proxy (`http://127.0.0.1:12334`), which rejected the connection. Explicitly setting `proxies={}` in `botocore.client.Config` for S3 clients and dynamically adding the MinIO endpoint to the `NO_PROXY` environment variable ensures direct connections to MinIO.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7463ca9-c914-4c9a-b20f-2208ab532873">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7463ca9-c914-4c9a-b20f-2208ab532873">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

