### PR TITLE
Fix phone number argument in user creation

### DIFF
--- a/backend/app/my_app1/serializers.py
+++ b/backend/app/my_app1/serializers.py
@@ -26,8 +26,8 @@ class UserSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         is_superuser = validated_data.pop('is_superuser', False)
         password = validated_data.pop('password')
-        email = validated_data.get('email')
-        phone_number = validated_data.get('phone_number')
+        email = validated_data.pop('email', None)
+        phone_number = validated_data.pop('phone_number', None)
 
         if is_superuser:
             user = User.objects.create_superuser(


### PR DESCRIPTION
Fixes `TypeError: got multiple values for keyword argument 'phone_number'` during user registration.

The `email` and `phone_number` fields were being passed twice to `create_user`/`create_superuser` (once explicitly and once via `**validated_data`), causing the `TypeError`. Popping them from `validated_data` before passing `**validated_data` resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-20f5f71e-476e-4474-a695-b5436fbe1f02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20f5f71e-476e-4474-a695-b5436fbe1f02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

