### PR TITLE
Fix mobile horizontal scrollbar bug

### DIFF
--- a/frontend/antrakt/src/index.css
+++ b/frontend/antrakt/src/index.css
@@ -9,6 +9,12 @@ body {
   --refresh-token: '';
 }
 
+/* Глобально убираем горизонтальную прокрутку, чтобы устранить белые поля справа на мобильных */
+html, body, #root {
+  overflow-x: hidden;
+  width: 100%;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;


### PR DESCRIPTION
Apply global CSS to eliminate unwanted horizontal scroll and blank space on mobile pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a5eac6f-39ab-43de-aa77-f264746fd042">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a5eac6f-39ab-43de-aa77-f264746fd042">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

