### PR TITLE
Fix actor card overflow issue

### DIFF
--- a/frontend/antrakt/src/pages/cards/ActorDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/ActorDetail.tsx
@@ -200,7 +200,7 @@ const ActorDetail: React.FC = () => {
                         boxShadow="0 5px 20px rgba(0, 0, 0, 0.5)"
                         p={{ base: 4, md: 8 }}
                     >
-                        <GridItem>
+                        <GridItem minW="0">
                             <Image
                                 src={actor.image_url}
                                 alt={actor.name}
@@ -214,8 +214,8 @@ const ActorDetail: React.FC = () => {
                             />
                         </GridItem>
 
-                        <GridItem>
-                            <VStack align="start" spacing={6}>
+                        <GridItem minW="0">
+                            <VStack align="start" spacing={6} sx={{ wordBreak: "break-word", overflowWrap: "anywhere" }}>
                                 <Heading as="h1" size="lg" color="white">{actor.name}</Heading>
                                 <Text color="whiteAlpha.800" fontSize="sm">{isFemale ? "Актриса" : "Актер"}</Text>
 


### PR DESCRIPTION
Prevent actor card details from overflowing by enabling text wrapping and adjusting grid item minimum width.

The previous layout allowed long strings (e.g., place of work, favorite items) to extend beyond the card boundaries. This PR addresses the issue by applying `wordBreak` and `overflowWrap` to the text container and setting `minW="0"` on the `GridItem`s to ensure content wraps correctly within the grid layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-3660e4dc-a37d-46a9-849e-7d6b9028f593">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3660e4dc-a37d-46a9-849e-7d6b9028f593">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

