### PR TITLE
Add admin panel button to navigation and mobile menu

### DIFF
--- a/frontend/antrakt/src/components/Navigation.tsx
+++ b/frontend/antrakt/src/components/Navigation.tsx
@@ -135,6 +135,16 @@ export default function Navigation() {
                         >
                             Войти
                         </Button>
+                    ) : user?.is_superuser ? (
+                        <Button
+                            variant="solid"
+                            bg={primaryColor}
+                            color={lightText}
+                            _hover={{ opacity: 0.9, transform: "translateY(-2px)" }}
+                            onClick={() => navigate('/admin')}
+                        >
+                            Админ-панель
+                        </Button>
                     ) : (
                         <Menu>
                             <MenuButton>
@@ -155,18 +165,6 @@ export default function Navigation() {
                                 >
                                     Профиль
                                 </MenuItem>
-
-                                {user?.is_superuser && (
-                                    <MenuItem
-                                        bg={darkBg}
-                                        _hover={{ bg: "#1a1a1a" }}
-                                        color={lightText}
-                                        onClick={() => navigate('/admin')} // Заменено window.location.href на navigate для согласованности
-                                    >
-                                        Админ-панель
-                                    </MenuItem>
-                                )}
-
                                 <MenuItem
                                     bg={darkBg}
                                     _hover={{ bg: "#1a1a1a" }}
@@ -224,6 +222,20 @@ export default function Navigation() {
                                 w="full"
                             >
                                 Войти
+                            </Button>
+                        )}
+
+                        {isAuthenticated && user?.is_superuser && (
+                            <Button
+                                variant="solid"
+                                bg={primaryColor}
+                                color={lightText}
+                                _hover={{ opacity: 0.9 }}
+                                onClick={() => navigate('/admin')}
+                                mt={2}
+                                w="full"
+                            >
+                                Админ-панель
                             </Button>
                         )}
                     </Stack>


### PR DESCRIPTION
Replace admin avatar with "Admin Panel" button on desktop and add it to the mobile menu for administrators.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5477ab2-aba5-4f93-b61a-a122551452aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5477ab2-aba5-4f93-b61a-a122551452aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

