### PR TITLE
Restore ticket link field functionality

### DIFF
--- a/backend/app/my_app1/views.py
+++ b/backend/app/my_app1/views.py
@@ -553,7 +553,7 @@ class AfishaList(APIView):
     def get(self, request, format=None):
         performances = Perfomances.objects.filter(afisha=True).values(
             'id', 'title', 'description', 'premiere_date',
-            'age_limit', 'image_url', 'the_cast', 'genre'
+            'age_limit', 'image_url', 'the_cast', 'genre', 'ticket_url'
         )
 
         archives = Archive.objects.filter(afisha=True).values(
@@ -570,7 +570,8 @@ class AfishaList(APIView):
                 'age_limit': p['age_limit'],
                 'image_url': p['image_url'],
                 'the_cast': p['the_cast'],
-                'genre': p['genre']
+                'genre': p['genre'],
+                'ticket_url': p.get('ticket_url')
             } for p in performances
         ]
 

--- a/frontend/antrakt/src/pages/AfishaPage.tsx
+++ b/frontend/antrakt/src/pages/AfishaPage.tsx
@@ -38,6 +38,7 @@ interface AfishaItem {
     image_url: string | null;
     genre?: string;
     the_cast?: string[];
+    ticket_url?: string; // Только для спектаклей
 }
 
 const AfishaPage: React.FC = () => {

--- a/frontend/antrakt/src/pages/admin/forms/PerformancesForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/PerformancesForm.tsx
@@ -82,6 +82,7 @@ interface Performance {
     deleted_at?: string | null;
     performances_image: string;
     images_list: string[]; // Добавлено поле для галереи
+    ticket_url?: string | null; // Ссылка на покупку билетов
 }
 
 const genres = [
@@ -441,6 +442,26 @@ export const PerformanceForm: React.FC<{
                             {currentPerformance.afisha ? "В 'Афиша'" : "В 'Спектакли'"}
                         </Text>
                     </FormControl>
+
+                    {currentPerformance.afisha && (
+                        <FormControl>
+                            <FormLabel display="flex" alignItems="center" gap={2}>
+                                <CFaImage color={primaryColor} />
+                                <Text as="span" fontWeight="semibold">Ссылка на покупку билетов</Text>
+                            </FormLabel>
+                            <Input
+                                name="ticket_url"
+                                type="url"
+                                placeholder="https://example.com/your-ticket-link"
+                                value={currentPerformance.ticket_url || ''}
+                                onChange={handleInputChange}
+                                focusBorderColor={primaryColor}
+                                bg="#333333"
+                                borderColor="#444444"
+                                _hover={{ borderColor: '#555555' }}
+                            />
+                        </FormControl>
+                    )}
 
                     <FormControl>
                         <FormLabel display="flex" alignItems="center" gap={2}>

--- a/frontend/antrakt/src/pages/cards/PerfomancesDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/PerfomancesDetail.tsx
@@ -56,6 +56,7 @@ interface Performance {
     afisha: boolean;
     image_url: string;
     images_list: string[] | null;
+    ticket_url?: string | null;
 }
 
 const PerformanceDetail: React.FC = () => {
@@ -351,6 +352,16 @@ const PerformanceDetail: React.FC = () => {
                                             <Text fontSize="md" color="gray.400">
                                                 <b>Актёрский состав:</b> {performance.the_cast.join(", ")}
                                             </Text>
+                                        )}
+                                        {performance.ticket_url && (
+                                            <Button
+                                                variant="solid"
+                                                colorScheme="red"
+                                                size={{ base: "sm", md: "md" }}
+                                                onClick={() => window.location.href = performance.ticket_url!}
+                                            >
+                                                Купить билет!
+                                            </Button>
                                         )}
                                     </VStack>
                                 </Grid>


### PR DESCRIPTION
Restores the conditional ticket link field in performance forms and the 'Buy Ticket' button on performance detail pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-86858090-521f-4dfe-9ba0-ced3802e89d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86858090-521f-4dfe-9ba0-ced3802e89d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

