### PR TITLE
Set up dev environment + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **Antrakt** theater website: a Django (DRF + SimpleJWT) backend with a
+PostgreSQL database and MinIO/S3 image storage, plus a React (Create React App + TypeScript +
+Chakra UI) frontend.
+
+Layout:
+- `backend/app` — Django project (`manage.py`, settings in `app/`, app code in `my_app1/`).
+- `frontend/antrakt` — CRA frontend.
+- `backend/database/init.sql` — PostgreSQL dump used to seed the dev DB (schema + data).
+
+### Services (none auto-start; the update script only refreshes dependencies)
+
+Start each in its own tmux session. PostgreSQL and MinIO binaries and the Python venv /
+node_modules are already present from the VM snapshot.
+
+1. **PostgreSQL** (port 5432) — start the cluster before the backend:
+   `sudo pg_ctlcluster 16 main start`
+   DB `antrakt`, user `postgres`, password `123` (matches `backend/app/app/settings.py` defaults).
+   The dump is already loaded into the snapshot; only reload it if the DB is missing:
+   `sudo -u postgres psql -d antrakt -f backend/database/init.sql`
+2. **MinIO** (S3 storage, ports 9000/9001) — start before the backend so the `antrakt-images`
+   bucket auto-creates on Django startup. The root password **must** be `minioadmin123` (the
+   backend's `MINIO_SECRET_KEY` default). Inline env vars do NOT propagate through
+   `tmux new-session`, so pass them via `env`:
+   `tmux ... new-session -d -s minio -- env MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin123 minio server /home/ubuntu/minio-data --console-address ":9001"`
+3. **Backend** (port 8000): from `backend/app`, run `../venv/bin/python manage.py runserver 0.0.0.0:8000`.
+4. **Frontend** (port 3000): from `frontend/antrakt`, run `BROWSER=none npm start`.
+   `apiClient.ts`/`AuthService.ts` hardcode the backend at `http://127.0.0.1:8000` / `http://localhost:8000`.
+
+### Known dev admin login
+
+`admin@antrakt.com` / `antrakt2026` (superuser; created during setup). The existing dumped
+superuser `np1r777@admin.com` has an unknown password.
+
+### Non-obvious gotchas
+
+- **Do NOT apply migration `0002`** (`manage.py migrate` fails on it). The dump's source DB ran
+  without it, and the seed data has duplicate `phone_number` values that violate the unique
+  index `0002` adds. `runserver` only prints an "unapplied migration" warning and works fine.
+- The dump schema has `user.phone_number` as **NOT NULL**, so any user you create directly must
+  set a (unique) `phone_number` even though the model marks it nullable.
+- Loading the dump on PostgreSQL 16 prints one harmless error about `transaction_timeout`
+  (a PG17-only setting); everything else restores cleanly.
+- **Tests are effectively non-functional / pre-existing breakage** (do not treat as your
+  regression): `src/utils/stringMatching.test.ts` is a manual console demo with no `test()`
+  blocks, and CRA's boilerplate `App.test.js` fails with `Cannot find module
+  '@chakra-ui/utils/context'` (Chakra UI v2 + Jest resolver issue). The Django app defines no tests.
+
+### Lint / typecheck
+
+Frontend: `npx tsc --noEmit` (clean) and `npx eslint src --ext .js,.jsx,.ts,.tsx`
+(0 errors, ~66 pre-existing warnings). There is no dedicated `lint` npm script; ESLint also runs
+during `npm start`/`npm run build`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the full development environment for the **Antrakt** theater app (Django + DRF/JWT backend, PostgreSQL, MinIO/S3 image storage, React + TypeScript frontend) and documents it for future agents.

The only code change is a new `AGENTS.md` capturing durable, non-obvious setup/run instructions. No application code was modified.

## What was set up
- **PostgreSQL 16**: DB `antrakt` seeded from `backend/database/init.sql` (11 shows, 17 actors, 18 users, etc.).
- **MinIO**: standalone server (root `minioadmin`/`minioadmin123`); the `antrakt-images` bucket auto-creates on Django startup.
- **Backend**: Python venv + `requirements.txt`; runs at `:8000`.
- **Frontend**: `npm install`; CRA dev server at `:3000`.

## Verification
- ✅ `manage.py check` — no issues
- ✅ `login/` API returns JWT for `admin@antrakt.com`
- ✅ `npx tsc --noEmit` — clean
- ✅ `npx eslint src` — 0 errors (66 pre-existing warnings)
- ✅ End-to-end GUI: logged in as admin and loaded the admin dashboard with live DB data

## Notes / pre-existing issues (documented in AGENTS.md)
- Migration `0002` must not be applied — seed data has duplicate `phone_number` values that violate the unique index it adds (source DB ran without it too).
- Frontend tests are non-functional: `stringMatching.test.ts` has no `test()` blocks, and CRA boilerplate `App.test.js` fails on a Chakra UI v2 / Jest resolver issue.

## Demo
[antrakt_admin_login_demo.mp4](https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fantrakt_admin_login_demo.mp4)

[Homepage](https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fantrakt_homepage.webp)
[Admin dashboard with live data](https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fantrakt_admin_dashboard.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

