### PR TITLE
Фикс: 403 в админ-панели (проверять is_superuser вместо is_staff) и вход со старым коротким паролем

### DIFF
--- a/backend/app/my_app1/tests.py
+++ b/backend/app/my_app1/tests.py
@@ -349,3 +349,28 @@ class ExtendedReviewTargetTests(TestCase):
         self.client.force_authenticate(self.user)
         resp = self.client.post(f'/archive{self.archive_afisha.id}/reviews/', {'text': 'ок'}, format='json')
         self.assertEqual(resp.status_code, 400)
+
+
+class AdminEndpointPermissionTests(TestCase):
+    """Админские эндпоинты открыты суперпользователю (даже если is_staff=False),
+    и закрыты для обычных пользователей."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_staffless_superuser_has_admin_access(self):
+        su = User.objects.create(
+            email='su@test.com', phone_number='+7-000-000-77-77',
+            profile_photo='', is_superuser=True, is_staff=False)
+        su.set_password('short')  # короткий пароль (как у старых аккаунтов)
+        su.save()
+        self.client.force_authenticate(su)
+        self.assertEqual(self.client.get('/users/').status_code, 200)
+        self.assertEqual(self.client.get('/reviews-admin/').status_code, 200)
+
+    def test_regular_user_denied_admin_access(self):
+        u = User.objects.create_user(
+            password='plainpass1', email='ru2@test.com', phone_number='+7-000-000-66-66')
+        self.client.force_authenticate(u)
+        self.assertEqual(self.client.get('/users/').status_code, 403)
+        self.assertEqual(self.client.get('/reviews-admin/').status_code, 403)

--- a/backend/app/my_app1/views.py
+++ b/backend/app/my_app1/views.py
@@ -21,10 +21,22 @@ from rest_framework_simplejwt.tokens import RefreshToken, AccessToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 
+class IsSuperUser(permissions.BasePermission):
+    """Доступ только суперпользователям (админам сайта).
+
+    В проекте роль «админ» определяется полем is_superuser (по нему пускает и
+    фронтенд/админ-панель), поэтому админские эндпоинты проверяют именно его,
+    а не is_staff (как в стандартном DRF IsAdminUser).
+    """
+    def has_permission(self, request, view):
+        user = request.user
+        return bool(user and user.is_authenticated and user.is_superuser)
+
+
 class UserList(APIView):
     model_class = User
     serializer_class = UserSerializer
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsSuperUser]
 
 
     def get(self, request, format=None):
@@ -36,7 +48,7 @@ class UserList(APIView):
 class UserListAdmin(APIView):
     model_class = User
     serializer_class = UserSerializer
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsSuperUser]
 
 
     def get(self, request, format=None):
@@ -1047,7 +1059,7 @@ class ReviewReactionView(APIView):
 
 class ReviewWarnView(APIView):
     """Отправка предупреждающего письма автору отзыва (только администратор)."""
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsSuperUser]
 
     def post(self, request, id, format=None):
         review = get_object_or_404(Review, id=id)
@@ -1090,7 +1102,7 @@ class MyReviewsList(APIView):
 
 class ReviewListAdmin(APIView):
     """Все отзывы (для модерации в админ-панели)."""
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsSuperUser]
 
     def get(self, request, format=None):
         reviews = (Review.objects

--- a/frontend/antrakt/src/components/AuthModal.tsx
+++ b/frontend/antrakt/src/components/AuthModal.tsx
@@ -114,7 +114,11 @@ export default function AuthModal({
 
     // Шаг входа / шаг 1 регистрации (данные)
     const handleSubmitCredentials = async () => {
-        const passwordError = validatePassword(password);
+        // При входе не навязываем минимальную длину — у старых аккаунтов
+        // пароль может быть короче 8 символов. Требование 8+ только для регистрации.
+        const passwordError = isRegister
+            ? validatePassword(password)
+            : (password ? "" : "Пароль обязателен");
         const identifierError = isRegister ? validateEmail(email) : validateEmailOrPhone(emailOrPhone);
         if (identifierError || passwordError) {
             setErrors({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Проблема
- Админ-аккаунт `np1r777@admin.com` имеет `is_superuser=true`, но `is_staff=false` (создан ещё из дампа).
- Фронтенд пускает в админ-панель по `is_superuser`, а бэкенд-эндпоинты отзывов/пользователей использовали DRF `IsAdminUser`, который проверяет `is_staff` → **403**.
- Дополнительно: фронт-валидация входа требовала пароль ≥8 символов, из-за чего нельзя было войти со старым коротким паролем (у бэкенда при входе такой проверки нет — это была чисто фронтовая блокировка).

## Что исправлено
- Добавлен permission-класс `IsSuperUser` (проверяет `is_superuser`) и применён ко всем админским эндпоинтам (`/users/`, `/users-admin/`, `/reviews-admin/`, warn) вместо `IsAdminUser`. Теперь бэкенд согласован с фронтом: «админ» = суперпользователь, независимо от `is_staff`.
- Форма входа больше не навязывает минимальную длину пароля (требование 8+ осталось только для **регистрации**). Существующие аккаунты со старым коротким паролем входят нормально.

## Проверка
- ✅ Суперпользователь с `is_staff=false` и коротким паролем: вход `200`, `/reviews-admin/` и `/users/` → `200` (было `403`).
- ✅ Обычный пользователь: `/reviews-admin/`, `/users/` → `403` (доступ по-прежнему закрыт).
- ✅ `python manage.py test my_app1` — 28 тестов (включая новые `AdminEndpointPermissionTests`), все зелёные.
- ✅ `npx tsc --noEmit` — чисто.

## Немедленный обходной путь (до деплоя фикса)
Если нужно вернуть доступ прямо сейчас на текущем `main`, можно один раз выставить `is_staff` суперпользователям:
```
python manage.py shell -c "from my_app1.models import User; User.objects.filter(is_superuser=True).update(is_staff=True)"
```
После деплоя этого PR обходной путь не нужен — доступ определяется по `is_superuser`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

