### PR TITLE
Зафиксировать версию MinIO и убрать рассинхрон конфигурации бакета

### DIFF
--- a/backend/app/my_app1/views.py
+++ b/backend/app/my_app1/views.py
@@ -785,6 +785,20 @@ class AfishaList(APIView):
         return Response(all_perf_afisha)
 
 
+def _minio_client():
+    """S3-клиент для MinIO. Единый источник настроек — Django settings
+    (endpoint/креды/бакет берутся из переменных окружения MINIO_*), чтобы не
+    было рассинхрона между кодом и docker-compose."""
+    return boto3.client(
+        's3',
+        endpoint_url=settings.AWS_S3_ENDPOINT_URL,
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        region_name=settings.AWS_S3_REGION_NAME,
+        config=BotoConfig(signature_version='s3v4', proxies={})
+    )
+
+
 class ImageUploadView(APIView):
     parser_classes = (MultiPartParser, FormParser)
     permission_classes = [permissions.AllowAny]
@@ -795,15 +809,8 @@ class ImageUploadView(APIView):
         image = request.FILES['image']
         folder = request.data.get('folder', 'images')
 
-        # Build S3 client
-        s3_client = boto3.client(
-            's3',
-            endpoint_url="http://localhost:9000",
-            aws_access_key_id="minioadmin",
-            aws_secret_access_key="minioadmin123",
-            config=BotoConfig(signature_version='s3v4', proxies={})
-        )
-        bucket = "antrakt-images"
+        s3_client = _minio_client()
+        bucket = settings.AWS_STORAGE_BUCKET_NAME
         extension = image.name.split('.')[-1].lower()
         object_key = f"{folder}/{uuid.uuid4().hex}.{extension}"
 
@@ -817,8 +824,8 @@ class ImageUploadView(APIView):
             }
         )
 
-        # Build public URL
-        public_url = f"http://localhost:9000/{bucket}/{object_key}"
+        # Публичный URL строим из настроенного endpoint MinIO.
+        public_url = f"{settings.AWS_S3_ENDPOINT_URL.rstrip('/')}/{bucket}/{object_key}"
         return Response({"success": True, "image_url": public_url, "message": "Изображение загружено"})
 
 
@@ -833,20 +840,14 @@ class ImageDeleteView(APIView):
         # Expected format: http(s)://<endpoint>/<bucket>/<key>
         path = parsed.path.lstrip('/')
         # If custom domain used as <endpoint>/<bucket>, first segment is bucket
-        bucket = "antrakt-images"
+        bucket = settings.AWS_STORAGE_BUCKET_NAME
         if path.startswith(bucket + '/'):
             object_key = path[len(bucket) + 1:]
         else:
             # fallback: whole path is key
             object_key = path
 
-        s3_client = boto3.client(
-            's3',
-            endpoint_url="http://localhost:9000",
-            aws_access_key_id="minioadmin",
-            aws_secret_access_key="minioadmin123",
-            config=BotoConfig(signature_version='s3v4', proxies={})
-        )
+        s3_client = _minio_client()
 
         try:
             s3_client.delete_object(Bucket=bucket, Key=object_key)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - MINIO_ENDPOINT=minio:9000
       - MINIO_ACCESS_KEY=minioadmin
       - MINIO_SECRET_KEY=minioadmin123
-      - MINIO_BUCKET_NAME=antrakt
+      - MINIO_BUCKET_NAME=antrakt-images
       - PYTHONUNBUFFERED=1
     depends_on:
       db:
@@ -71,9 +71,12 @@ services:
       - /app/node_modules
     restart: unless-stopped
 
-  # MinIO для хранения изображений
+  # MinIO для хранения изображений.
+  # ВАЖНО: версия зафиксирована намеренно. Тег `latest` опасен — обновление
+  # версии может изменить формат хранения на диске и «спрятать» ранее
+  # загруженные объекты. Обновлять только осознанно и с бэкапом бакета.
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: minio
     ports:
       - "9000:9000"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Зачем
После обновления `minio/minio:latest` изображения «пропали» из бакета (данные на томе целы, но новый MinIO их не отдавал). Чтобы такое не повторялось и чтобы конфиг был согласованным.

## Что сделано
1. **Зафиксирована версия MinIO** в `docker-compose.yml`: `minio/minio:latest` → `minio/minio:RELEASE.2025-09-07T16-13-09Z`. Тег `latest` опасен — обновление версии может сменить формат хранения на диске и «спрятать» ранее загруженные объекты. Теперь версия не «уедет» при перезапуске/выходе из гибернации.
2. **Устранён рассинхрон бакета.** Раньше в `docker-compose.yml` у backend было `MINIO_BUCKET_NAME=antrakt`, но `settings.py` по умолчанию использует `antrakt-images`, а вьюхи загрузки/удаления **захардкоживали** бакет/endpoint/креды (`antrakt-images`, `http://localhost:9000`, `minioadmin`).
   - `ImageUploadView`/`ImageDeleteView` теперь берут бакет, endpoint и креды из **Django settings** (переменные `MINIO_*`) — единый источник правды.
   - В `docker-compose.yml` `MINIO_BUCKET_NAME` приведён к `antrakt-images` (реальный бакет, где лежат данные).
   - Значения по умолчанию в settings совпадают с прежними захардкоженными, поэтому в dev поведение не изменилось, но теперь конфиг конфигурируем и согласован (в т.ч. заработает endpoint `minio:9000` при запуске backend в Docker).

## Проверки
- ✅ Загрузка/удаление изображения сквозняком через API (`/upload-image/` → `GET` объекта `200` → `/delete-image/` → `GET` `404`); публичный URL остался `http://localhost:9000/antrakt-images/...` (идентично прежнему).
- ✅ `python manage.py test my_app1` — 32 теста, все зелёные.
- ✅ `manage.py check` — без ошибок.

## Важно про уже пропавшие фото
Этот PR предотвращает повторение, но **не восстанавливает** уже «спрятанные» объекты автоматически. Данные физически на месте на томе `minio_data` (формат `xl-single`: папки-объекты с `xl.meta` + `part.1`). Восстановление — по шагам из обсуждения (проверить монтирование тома в контейнер, поднять MinIO через фиксированный compose, при необходимости вытащить `part.1`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

