### PR TITLE
Fix VK parser SSL CERTIFICATE_VERIFY_FAILED: use certifi CA bundle

### DIFF
--- a/backend/app/app/settings.py
+++ b/backend/app/app/settings.py
@@ -275,6 +275,9 @@ VK_SESSION_COOKIE = config('VK_SESSION_COOKIE', default='')
 VK_ACCESS_TOKEN = config('VK_ACCESS_TOKEN', default='')
 VK_API_VERSION = config('VK_API_VERSION', default='5.199')
 VK_GROUP_DOMAIN = config('VK_GROUP_DOMAIN', default='tc_antrakt')
+# Проверка SSL-сертификата при запросах к ВК. Используется бандл certifi.
+# Отключать (False) только как временный обходной путь при проблемах с CA.
+VK_SSL_VERIFY = config('VK_SSL_VERIFY', default=True, cast=bool)
 
 # Настройки для работы с разными типами БД
 print("Используется PostgreSQL с полной функциональностью")

--- a/backend/app/my_app1/vk_parser.py
+++ b/backend/app/my_app1/vk_parser.py
@@ -19,6 +19,7 @@
 * Дубли исключаются по (owner_id, post_id, comment_id).
 """
 import re
+import ssl
 import html
 import json
 import hashlib
@@ -30,6 +31,31 @@ from django.conf import settings
 from django.utils import timezone
 
 from .models import SiteReview, VkParserState
+
+
+def _ssl_context():
+    """SSL-контекст с надёжным набором корневых сертификатов.
+
+    На некоторых системах системное хранилище CA недоступно из Python
+    (ошибка `CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate`),
+    поэтому явно используем бандл `certifi`. При крайней необходимости проверку
+    сертификата можно отключить настройкой VK_SSL_VERIFY=False (небезопасно —
+    только как временный обходной путь).
+    """
+    if not getattr(settings, 'VK_SSL_VERIFY', True):
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
+def _urlopen(req, timeout=30):
+    return urllib.request.urlopen(req, timeout=timeout, context=_ssl_context())
 
 VK_API = 'https://api.vk.com/method/'
 MOBILE_UA = ('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) '
@@ -85,7 +111,7 @@ class ApiBackend:
         q['v'] = getattr(settings, 'VK_API_VERSION', '5.199')
         url = VK_API + method + '?' + urllib.parse.urlencode(q)
         try:
-            with urllib.request.urlopen(url, timeout=30) as resp:
+            with _urlopen(url, timeout=30) as resp:
                 data = json.loads(resp.read().decode('utf-8'))
         except Exception as exc:
             raise VkParserError(f'Ошибка запроса к ВК ({method}): {exc}')
@@ -186,7 +212,7 @@ class HtmlBackend:
             'Cookie': self.cookie,
         })
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            with _urlopen(req, timeout=30) as resp:
                 return resp.read().decode('utf-8', 'replace')
         except Exception as exc:
             raise VkParserError(f'Ошибка загрузки {url}: {exc}')


### PR DESCRIPTION
- All VK requests go through _urlopen with an SSL context built from certifi (fixes 'unable to get local issuer certificate' on systems without a usable CA store)
- Add VK_SSL_VERIFY setting (default True) as a last-resort fallback