### PR TITLE
Фикс: восстановление пользователей из админ-панели

### DIFF
--- a/backend/app/my_app1/serializers.py
+++ b/backend/app/my_app1/serializers.py
@@ -25,8 +25,11 @@ class UserSerializer(serializers.ModelSerializer):
         }
 
     def validate(self, attrs):
-        email = attrs.get('email')
-        phone_number = attrs.get('phone_number')
+        # На частичном обновлении (например, восстановление пользователя —
+        # передаётся только deleted_at) берём недостающие значения из уже
+        # сохранённого объекта, иначе валидация ломала бы restore/soft-delete.
+        email = attrs.get('email', getattr(self.instance, 'email', None))
+        phone_number = attrs.get('phone_number', getattr(self.instance, 'phone_number', None))
         if not email and not phone_number:
             raise serializers.ValidationError("Требуется email или номер телефона")
         return attrs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<![CDATA[## Проблема
Из админ-панели не восстанавливались пользователи (кнопка «Восстановить»). Запрос `PUT /user<id>/ {deleted_at: null}` падал с ошибкой 400 «Требуется email или номер телефона».

## Причина
`UserSerializer.validate` требовал email/телефон при **любом** сохранении. При восстановлении передаётся только `deleted_at`, поэтому email и телефон отсутствовали в `attrs` → валидация падала. (То же ломало и мягкое удаление через PUT.)

## Фикс
`validate` теперь на частичном обновлении берёт недостающие значения из уже сохранённого объекта (`self.instance`); требование «email или телефон» осталось для создания.

## Тестирование
- API: soft-deleted пользователь → `PUT /user<id>/ {deleted_at: null}` с токеном админа → **HTTP 200**, `deleted_at = None`. До фикса — 400.
- UI: в разделе «Пользователи» нажатие «Восстановить» — тост «Пользователь восстановлен», бейдж «УДАЛЕНО» пропадает, карточка снова активна, без ошибок.
- Создание пользователя без email и телефона по-прежнему отклоняется.

[User restored in admin](https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuser_restored.webp)
]]>

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

