### PR TITLE
Подготовка к продакшену: hardening Django, конфиг API-URL, Docker/Compose/Caddy

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,43 @@
+# ==========================================================================
+# Пример продакшен-конфигурации. Скопируйте в .env.prod и заполните значения:
+#   cp .env.prod.example .env.prod
+# Запуск:
+#   docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
+# НЕ коммитьте .env.prod в git!
+# ==========================================================================
+
+# --- Домен (без схемы). Нужны A-записи: DOMAIN, api.DOMAIN, s3.DOMAIN ---
+DOMAIN=example.com
+
+# --- Django ---
+# Сгенерируйте длинный случайный ключ, например:
+#   python -c "import secrets; print(secrets.token_urlsafe(64))"
+SECRET_KEY=ЗАМЕНИТЕ_НА_ДЛИННЫЙ_СЛУЧАЙНЫЙ_КЛЮЧ
+
+# --- PostgreSQL ---
+DATABASE_NAME=antrakt
+DATABASE_USER=antrakt
+DATABASE_PASSWORD=ЗАМЕНИТЕ_НА_НАДЁЖНЫЙ_ПАРОЛЬ
+
+# --- MinIO (S3-хранилище изображений) ---
+MINIO_ACCESS_KEY=ЗАМЕНИТЕ_логин_minio
+MINIO_SECRET_KEY=ЗАМЕНИТЕ_надёжный_пароль_minio
+MINIO_BUCKET_NAME=antrakt-images
+
+# --- Почта (Яндекс SMTP): нужна для кода регистрации и восстановления пароля ---
+# Пароль приложения создаётся в Яндекс ID -> Безопасность -> Пароли приложений -> Почта (SMTP).
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=smtp.yandex.ru
+EMAIL_PORT=465
+EMAIL_USE_SSL=True
+EMAIL_USE_TLS=False
+EMAIL_HOST_USER=your_mail@yandex.ru
+EMAIL_HOST_PASSWORD=пароль_приложения_яндекса
+DEFAULT_FROM_EMAIL=your_mail@yandex.ru
+
+# --- Парсер отзывов ВК (необязательно). Хотя бы одно из двух: ---
+# HTML: cookie remixsid из браузера, где вы вошли во ВКонтакте.
+VK_SESSION_COOKIE=
+# ЛИБО API: сервисный ключ вашего приложения dev.vk.com.
+VK_ACCESS_TOKEN=
+VK_GROUP_DOMAIN=tc_antrakt

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ logs/
 # Temporary files
 tmp/
 temp/
+# Production env files (contain secrets)
+.env.prod
+.env.*.local

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,19 @@
+# Reverse-proxy с автоматическим HTTPS (Let's Encrypt).
+# Домены берутся из переменной окружения DOMAIN (см. .env.prod).
+# Требуется: публичный домен, A-записи domain / api.domain / s3.domain на сервер,
+# открытые порты 80 и 443.
+
+{$DOMAIN} {
+	encode gzip
+	reverse_proxy frontend:80
+}
+
+api.{$DOMAIN} {
+	encode gzip
+	reverse_proxy backend:8000
+}
+
+# Публичный доступ к изображениям из MinIO.
+s3.{$DOMAIN} {
+	reverse_proxy minio:9000
+}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,105 @@
+# Развёртывание в продакшене
+
+Стек: Django (gunicorn) + PostgreSQL + MinIO (изображения) + React (nginx),
+единый вход через Caddy с автоматическим HTTPS.
+
+Публичные адреса после запуска:
+- `https://<DOMAIN>` — сайт (React);
+- `https://api.<DOMAIN>` — backend (Django/DRF), админка Django: `https://api.<DOMAIN>/admin/`;
+- `https://s3.<DOMAIN>` — изображения (MinIO).
+
+---
+
+## 1. Что нужно подготовить самому (обязательно)
+
+1. **Сервер** с Docker и Docker Compose (Linux, 2+ ГБ RAM), открытые порты **80** и **443**.
+2. **Домен** и DNS `A`-записи на IP сервера для трёх имён:
+   - `DOMAIN` (например `nnt.ru`),
+   - `api.DOMAIN`,
+   - `s3.DOMAIN`.
+   (Caddy сам получит SSL-сертификаты Let’s Encrypt для всех трёх.)
+3. **Файл `.env.prod`** — скопируйте из примера и заполните:
+   ```bash
+   cp .env.prod.example .env.prod
+   ```
+   - `DOMAIN` — ваш домен.
+   - `SECRET_KEY` — длинный случайный ключ:
+     `python -c "import secrets; print(secrets.token_urlsafe(64))"`.
+   - `DATABASE_PASSWORD` — надёжный пароль БД.
+   - `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` — логин/пароль хранилища.
+   - Почта (см. раздел 3) и, при необходимости, ВК-парсер (раздел 4).
+
+## 2. Запуск
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
+```
+
+Что произойдёт автоматически:
+- поднимутся PostgreSQL и MinIO (с постоянными томами), создастся бакет с публичным чтением;
+- backend дождётся БД, применит миграции, соберёт статику и запустит gunicorn;
+- соберётся и раздастся фронтенд;
+- Caddy получит HTTPS-сертификаты и проксирует все три поддомена.
+
+Создать суперпользователя (админа сайта):
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec backend python manage.py createsuperuser
+```
+> Важно: у пользователя должен быть уникальный `phone_number` (в БД поле NOT NULL).
+> Роль «админ» на сайте определяется флагом `is_superuser`.
+
+Обновление после изменений в коде:
+```bash
+git pull
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
+```
+
+## 3. Почта (ОБЯЗАТЕЛЬНО для регистрации и восстановления пароля)
+
+Без SMTP код подтверждения регистрации и новый пароль **не отправляются**
+(в dev они просто печатаются в консоль). Для реальной отправки нужен почтовый
+ящик и **пароль приложения**.
+
+Пример для Яндекс.Почты:
+1. Заведите/используйте ящик `...@yandex.ru`.
+2. Яндекс ID → **Безопасность** → **Пароли приложений** → тип **«Почта (SMTP)»** → создайте пароль.
+3. В `.env.prod` укажите:
+   ```env
+   EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+   EMAIL_HOST=smtp.yandex.ru
+   EMAIL_PORT=465
+   EMAIL_USE_SSL=True
+   EMAIL_HOST_USER=ваш_ящик@yandex.ru
+   EMAIL_HOST_PASSWORD=пароль_приложения
+   DEFAULT_FROM_EMAIL=ваш_ящик@yandex.ru
+   ```
+   `DEFAULT_FROM_EMAIL` должен совпадать с `EMAIL_HOST_USER` (требование Яндекса).
+
+Другой провайдер — поменяйте `EMAIL_HOST`/`EMAIL_PORT` и режим SSL/TLS.
+
+## 4. Парсер отзывов ВК (необязательно)
+
+Чтобы секция «Что говорят о нас» наполнялась из группы ВК, задайте **одно** из:
+- `VK_SESSION_COOKIE` — значение cookie `remixsid` из браузера, где вы вошли во ВКонтакте (HTML-парсинг), **либо**
+- `VK_ACCESS_TOKEN` — сервисный ключ вашего приложения `dev.vk.com` (надёжнее).
+
+Запуск парсера вручную / по расписанию (раз в 2 недели, cron на сервере):
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec backend python manage.py parse_vk_reviews
+```
+Также есть кнопка «Обновить из ВК» в админке сайта.
+
+## 5. Безопасность — что сделать самому
+
+- **Смените ранее засветившиеся секреты.** В истории git были реальные значения
+  пароля почты и ВК-токена/куки — их нужно **отозвать/сменить** (сменить пароль
+  приложения почты, разлогинить сессии ВК). В коде значения по умолчанию убраны —
+  всё берётся из окружения.
+- Не коммитьте `.env.prod` (уже в `.gitignore`).
+- Регулярно делайте бэкапы томов `pg_data` (БД) и `minio_data` (изображения).
+
+## 6. Проверка после запуска
+
+- Сайт открывается по `https://<DOMAIN>`, изображения грузятся.
+- Логин/регистрация работают, письма приходят.
+- Админка сайта (`https://<DOMAIN>/admin`) и Django-админка (`https://api.<DOMAIN>/admin/`) доступны.

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,32 @@
+# Продакшен-образ Django backend (gunicorn).
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+# Системные зависимости для psycopg/сборки + curl для healthcheck.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libpq-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Django-проект лежит в backend/app -> кладём его в /app (manage.py в корне).
+COPY app/ /app/
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["gunicorn", "app.wsgi:application", \
+     "--bind", "0.0.0.0:8000", \
+     "--workers", "3", \
+     "--timeout", "120", \
+     "--access-logfile", "-", \
+     "--error-logfile", "-"]

--- a/backend/app/app/settings.py
+++ b/backend/app/app/settings.py
@@ -22,13 +22,25 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
+from django.core.exceptions import ImproperlyConfigured
+
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-tz-^0_e%qv2&ac4e1$viah-tr=gby9=0grcdeu_yp0kcop^_1%'
+# В dev используется небезопасный ключ по умолчанию; на проде ОБЯЗАТЕЛЬНО задайте
+# переменную окружения SECRET_KEY (случайная длинная строка).
+_INSECURE_SECRET_KEY = 'django-insecure-tz-^0_e%qv2&ac4e1$viah-tr=gby9=0grcdeu_yp0kcop^_1%'
+SECRET_KEY = config('SECRET_KEY', default=_INSECURE_SECRET_KEY)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', default=True, cast=bool)
 
-ALLOWED_HOSTS = ['*']
+# Список хостов через запятую: "example.com,api.example.com". В dev — все.
+ALLOWED_HOSTS = [h.strip() for h in config('ALLOWED_HOSTS', default='*').split(',') if h.strip()]
+
+# Защита от запуска продакшена с dev-ключом.
+if not DEBUG and SECRET_KEY == _INSECURE_SECRET_KEY:
+    raise ImproperlyConfigured(
+        'Задайте переменную окружения SECRET_KEY для продакшена (DEBUG=False).'
+    )
 
 
 # Application definition
@@ -52,6 +64,8 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    # WhiteNoise отдаёт статику Django (админка, DRF, Swagger) в проде без nginx.
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -116,7 +130,25 @@ SIMPLE_JWT = {
     'SLIDING_TOKEN_REFRESH_LIFETIME': None,
 }
 
-CORS_ALLOW_ALL_ORIGINS = True  # Для разработки, в продакшене укажите конкретные домены
+# CORS/CSRF: в dev разрешаем всё; в проде выключите CORS_ALLOW_ALL_ORIGINS и
+# перечислите домены фронтенда в CORS_ALLOWED_ORIGINS / CSRF_TRUSTED_ORIGINS.
+CORS_ALLOW_ALL_ORIGINS = config('CORS_ALLOW_ALL_ORIGINS', default=True, cast=bool)
+CORS_ALLOWED_ORIGINS = [o.strip() for o in config('CORS_ALLOWED_ORIGINS', default='').split(',') if o.strip()]
+CSRF_TRUSTED_ORIGINS = [o.strip() for o in config('CSRF_TRUSTED_ORIGINS', default='').split(',') if o.strip()]
+CORS_ALLOW_CREDENTIALS = True
+
+# HTTPS-настройки безопасности включаются флагом SECURE_HTTPS=True (за reverse-proxy).
+SECURE_HTTPS = config('SECURE_HTTPS', default=False, cast=bool)
+if SECURE_HTTPS:
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+
 AUTH_USER_MODEL = 'my_app1.User'
 
 # Database
@@ -178,8 +210,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
-# STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]  # Для React build
-# STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')   # Для collectstatic
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')  # Для collectstatic (прод)
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
@@ -240,11 +271,16 @@ if USE_MINIO_STORAGE:
     except Exception:
         pass
 
-    # Use S3-backed storage for Django file storage
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-
     # MEDIA_URL should point to MinIO public HTTP endpoint
     MEDIA_URL = f"{AWS_S3_URL_PROTOCOL}//{AWS_S3_CUSTOM_DOMAIN}/"
+
+# Хранилища (Django 5): статику отдаёт WhiteNoise (сжатие + кэш-заголовки).
+# Загрузка изображений идёт напрямую через boto3 (см. views), поэтому для
+# файлов достаточно обычного FileSystemStorage.
+STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "whitenoise.storage.CompressedStaticFilesStorage"},
+}
 
 # Email configuration (Яндекс SMTP)
 # По умолчанию используется console-backend (письма печатаются в консоль),
@@ -260,7 +296,7 @@ EMAIL_PORT = config('EMAIL_PORT', default=465, cast=int)
 EMAIL_USE_SSL = config('EMAIL_USE_SSL', default=True, cast=bool)
 EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=False, cast=bool)
 EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
-EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='vloscddlwlypenvr')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
 DEFAULT_FROM_EMAIL = config(
     'DEFAULT_FROM_EMAIL',
     default=(EMAIL_HOST_USER or 'noreply@antrakt.local')
@@ -269,10 +305,10 @@ DEFAULT_FROM_EMAIL = config(
 # --- Парсер отзывов из ВКонтакте ---
 # Способ 1 (HTML): cookie `remixsid` браузера, где вы вошли во ВКонтакте
 # (парсинг m.vk.com; НЕ требует прав администратора группы и токена).
-VK_SESSION_COOKIE = config('VK_SESSION_COOKIE', default='1_LX9C4u10fwMDAqg8f6dm7NHlVlyGGaTZQsBCJZ4tOjFrYEWx0KlMQKWGgB0dQJExPq73wsylVBUiXLmHLhuUvg')
+VK_SESSION_COOKIE = config('VK_SESSION_COOKIE', default='')
 # Способ 2 (API): сервисный ключ доступа вашего приложения dev.vk.com
 # (тоже НЕ требует прав администратора группы; надёжнее HTML).
-VK_ACCESS_TOKEN = config('VK_ACCESS_TOKEN', default='bf4d5ac1bf4d5ac1bf4d5ac149bc0f6151bbf4dbf4d5ac1d5029410521aaf8cc0d6f6ea')
+VK_ACCESS_TOKEN = config('VK_ACCESS_TOKEN', default='')
 VK_API_VERSION = config('VK_API_VERSION', default='5.199')
 VK_GROUP_DOMAIN = config('VK_GROUP_DOMAIN', default='tc_antrakt')
 

--- a/backend/app/my_app1/views.py
+++ b/backend/app/my_app1/views.py
@@ -910,8 +910,14 @@ class ImageUploadView(APIView):
             }
         )
 
-        # Публичный URL строим из настроенного endpoint MinIO.
-        public_url = f"{settings.AWS_S3_ENDPOINT_URL.rstrip('/')}/{bucket}/{object_key}"
+        # Публичный URL строим из ПУБЛИЧНОГО адреса хранилища (MEDIA_URL),
+        # а не из внутреннего endpoint (например, http://minio:9000), чтобы
+        # ссылка была доступна из браузера и в продакшене.
+        public_base = getattr(settings, 'MEDIA_URL', '')
+        if public_base and '//' in public_base:
+            public_url = f"{public_base.rstrip('/')}/{object_key}"
+        else:
+            public_url = f"{settings.AWS_S3_ENDPOINT_URL.rstrip('/')}/{bucket}/{object_key}"
         return Response({"success": True, "image_url": public_url, "message": "Изображение загружено"})
 
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+echo "==> Ожидание базы данных..."
+python - <<'PY'
+import os, time
+import psycopg
+
+cfg = dict(
+    host=os.environ.get('DATABASE_HOST', 'db'),
+    port=os.environ.get('DATABASE_PORT', '5432'),
+    dbname=os.environ.get('DATABASE_NAME', 'antrakt'),
+    user=os.environ.get('DATABASE_USER', 'postgres'),
+    password=os.environ.get('DATABASE_PASSWORD', ''),
+    connect_timeout=3,
+)
+for attempt in range(60):
+    try:
+        psycopg.connect(**cfg).close()
+        print("==> База данных доступна")
+        break
+    except Exception as exc:
+        print(f"    ждём БД ({attempt + 1}/60): {exc}")
+        time.sleep(2)
+else:
+    raise SystemExit("База данных недоступна — прерываю запуск")
+PY
+
+echo "==> Применение миграций..."
+python manage.py migrate --noinput
+
+echo "==> Сбор статики..."
+python manage.py collectstatic --noinput
+
+echo "==> Запуск приложения..."
+exec "$@"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,4 +34,5 @@ typing_extensions==4.14.0
 tzdata==2025.2
 uritemplate==4.2.0
 urllib3==2.5.0
+whitenoise==6.9.0
 click

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,124 @@
+# Продакшен-развёртка «Норильский народный театр».
+# Запуск:  docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
+#
+# Публичные адреса (через Caddy с авто-HTTPS):
+#   https://<DOMAIN>       — сайт (React)
+#   https://api.<DOMAIN>   — backend (Django/DRF, админка /admin/)
+#   https://s3.<DOMAIN>    — изображения (MinIO)
+name: antrakt-prod
+
+services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: ${DATABASE_NAME}
+      POSTGRES_USER: ${DATABASE_USER}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER} -d ${DATABASE_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  minio:
+    # Версия зафиксирована намеренно (тег latest может сменить формат хранения).
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY}
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+
+  # Одноразовое создание бакета и настройка публичного чтения изображений.
+  minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} &&
+      mc mb --ignore-existing local/${MINIO_BUCKET_NAME} &&
+      mc anonymous set download local/${MINIO_BUCKET_NAME} &&
+      echo 'Бакет ${MINIO_BUCKET_NAME} готов (публичное чтение включено)'
+      "
+    restart: "no"
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
+    env_file:
+      - .env.prod
+    environment:
+      # Инфраструктурные адреса внутри compose-сети.
+      DATABASE_HOST: db
+      DATABASE_PORT: 5432
+      MINIO_ENDPOINT: http://minio:9000
+      # Публичный адрес хранилища для ссылок на изображения.
+      MINIO_CUSTOM_DOMAIN: s3.${DOMAIN}/${MINIO_BUCKET_NAME}
+      MINIO_URL_PROTOCOL: "https:"
+      # Прод-безопасность.
+      DEBUG: "False"
+      SECURE_HTTPS: "True"
+      ALLOWED_HOSTS: api.${DOMAIN}
+      CORS_ALLOW_ALL_ORIGINS: "False"
+      CORS_ALLOWED_ORIGINS: https://${DOMAIN}
+      CSRF_TRUSTED_ORIGINS: https://${DOMAIN},https://api.${DOMAIN}
+    depends_on:
+      db:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend/antrakt
+      dockerfile: Dockerfile.prod
+      args:
+        REACT_APP_API_URL: https://api.${DOMAIN}
+        REACT_APP_MEDIA_URL: https://s3.${DOMAIN}
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - frontend
+      - backend
+      - minio
+    restart: unless-stopped
+
+volumes:
+  pg_data:
+  minio_data:
+  caddy_data:
+  caddy_config:

--- a/frontend/antrakt/Dockerfile.prod
+++ b/frontend/antrakt/Dockerfile.prod
@@ -1,0 +1,24 @@
+# Продакшен-образ фронтенда: сборка CRA -> раздача через nginx.
+FROM node:18-alpine AS build
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# Адреса backend/медиа вшиваются в бандл на этапе сборки.
+ARG REACT_APP_API_URL
+ARG REACT_APP_MEDIA_URL
+ENV REACT_APP_API_URL=$REACT_APP_API_URL \
+    REACT_APP_MEDIA_URL=$REACT_APP_MEDIA_URL \
+    GENERATE_SOURCEMAP=false \
+    CI=false
+
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/antrakt/nginx.conf
+++ b/frontend/antrakt/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: любые маршруты отдаём index.html (react-router разрулит на клиенте).
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Долгое кэширование статических ассетов (у них хэш в имени).
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|webp|woff2?)$ {
+        expires 30d;
+        add_header Cache-Control "public";
+        try_files $uri =404;
+    }
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+}

--- a/frontend/antrakt/src/components/Footer.tsx
+++ b/frontend/antrakt/src/components/Footer.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-icons/fa";
 import type { ComponentWithAs, IconProps } from "@chakra-ui/react";
 import { useSiteContent } from "../contexts/SiteContentContext";
+import { MEDIA_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionLink = motion(Link);
@@ -222,7 +223,7 @@ export default function Footer() {
                         </Heading>
 
                         <Image
-                            src="http://localhost:9000/antrakt-images/unnamed.jpg" // Placeholder для логотипа партнёра
+                            src={`${MEDIA_URL}/antrakt-images/unnamed.jpg`} // Placeholder для логотипа партнёра
                             alt="Логотип партнёра"
                             mb={4}
                             maxH="130px" // Ограничение высоты для логотипа

--- a/frontend/antrakt/src/components/ReviewsSection.tsx
+++ b/frontend/antrakt/src/components/ReviewsSection.tsx
@@ -27,8 +27,9 @@ import {
 import { FaTrash, FaExclamationTriangle } from 'react-icons/fa';
 import axios from 'axios';
 import { useAuth } from '../contexts/AuthContext';
+import { API_URL } from '../config';
 
-const API = 'http://localhost:8000';
+const API = `${API_URL}`;
 const primaryColor = '#f2f2f2';
 
 const CFaTrash = chakra(FaTrash as any);

--- a/frontend/antrakt/src/config.ts
+++ b/frontend/antrakt/src/config.ts
@@ -1,0 +1,8 @@
+// Базовый адрес backend API.
+// В разработке — http://localhost:8000. В продакшене задайте REACT_APP_API_URL
+// на этапе сборки (например, https://api.example.com). Завершающий слэш убирается.
+export const API_URL = (process.env.REACT_APP_API_URL || 'http://localhost:8000').replace(/\/+$/, '');
+
+// Публичный адрес хранилища изображений (MinIO/S3). Прежние захардкоженные
+// ссылки вида http://localhost:9000 заменяются на этот адрес.
+export const MEDIA_URL = (process.env.REACT_APP_MEDIA_URL || 'http://localhost:9000').replace(/\/+$/, '');

--- a/frontend/antrakt/src/contexts/SiteContentContext.tsx
+++ b/frontend/antrakt/src/contexts/SiteContentContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import axios from 'axios';
+import { API_URL } from '../config';
 
 export interface SiteContentItem {
     id: number;
@@ -29,7 +30,7 @@ export const SiteContentProvider: React.FC<{ children: React.ReactNode }> = ({ c
     const [content, setContent] = useState<Record<string, string>>({});
 
     const load = useCallback(() => {
-        axios.get('http://localhost:8000/site-content/')
+        axios.get(`${API_URL}/site-content/`)
             .then(res => {
                 const map: Record<string, string> = {};
                 (res.data || []).forEach((item: SiteContentItem) => {

--- a/frontend/antrakt/src/pages/AboutTheatre.tsx
+++ b/frontend/antrakt/src/pages/AboutTheatre.tsx
@@ -4,6 +4,7 @@ import Footer from "../components/Footer";
 import Navigation from "../components/Navigation";
 import { Box, Flex, Heading, Text, VStack, Grid, GridItem, Image, Center } from "@chakra-ui/react";
 import { useSiteContent } from "../contexts/SiteContentContext";
+import { MEDIA_URL } from '../config';
 
 const MotionBox = motion(Box);
 
@@ -80,7 +81,7 @@ const AboutTheatre: React.FC = () => {
 
                         <GridItem>
                             <Image
-                                src="http://localhost:9000/antrakt-images/Общая.png"
+                                src={`${MEDIA_URL}/antrakt-images/Общая.png`}
                                 alt="Норильский народный театр"
                                 w="100%"
                                 h="auto"

--- a/frontend/antrakt/src/pages/AchievementsPage.tsx
+++ b/frontend/antrakt/src/pages/AchievementsPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
 import axios from "axios";
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionGrid = motion(Grid);
@@ -29,7 +30,7 @@ const AchievementsPage: React.FC = () => {
         const fetchAchievements = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get("http://localhost:8000/achievements/");
+                const response = await axios.get(`${API_URL}/achievements/`);
                 setAchievements(response.data);
             } catch (err) {
                 setError("Ошибка загрузки достижений");

--- a/frontend/antrakt/src/pages/AfishaPage.tsx
+++ b/frontend/antrakt/src/pages/AfishaPage.tsx
@@ -22,6 +22,7 @@ import { motion } from "framer-motion";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
 import { ChevronRightIcon } from "@chakra-ui/icons";
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionGrid = motion(Grid);
@@ -52,7 +53,7 @@ const AfishaPage: React.FC = () => {
         const fetchAfishaItems = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get("http://localhost:8000/afisha");
+                const response = await axios.get(`${API_URL}/afisha`);
                 // Фильтрация по afisha=true убрана, так как API возвращает объединённый список
                 setAfishaItems(response.data);
             } catch (err) {

--- a/frontend/antrakt/src/pages/ArchivePage.tsx
+++ b/frontend/antrakt/src/pages/ArchivePage.tsx
@@ -19,6 +19,7 @@ import {
 import { motion } from "framer-motion";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionGrid = motion(Grid);
@@ -49,7 +50,7 @@ const ArchivePage: React.FC = () => {
         const fetchProjects = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get("http://localhost:8000/archive");
+                const response = await axios.get(`${API_URL}/archive`);
                 const pastProjects = response.data.filter((proj: ArchiveProject) => proj.afisha === false);
                 setProjects(pastProjects);
             } catch (err) {

--- a/frontend/antrakt/src/pages/NewsPage.tsx
+++ b/frontend/antrakt/src/pages/NewsPage.tsx
@@ -22,6 +22,7 @@ import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionButton = motion(Button);
@@ -54,7 +55,7 @@ const NewsPage: React.FC = () => {
                 setIsLoading(true);
                 setError(null);
 
-                const response = await axios.get("http://localhost:8000/news");
+                const response = await axios.get(`${API_URL}/news`);
 
                 if (response.status !== 200) {
                     throw new Error(`Ошибка загрузки: ${response.status} ${response.statusText}`);

--- a/frontend/antrakt/src/pages/PerformancesPage.tsx
+++ b/frontend/antrakt/src/pages/PerformancesPage.tsx
@@ -21,6 +21,7 @@ import { motion } from "framer-motion";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
 import { ChevronRightIcon } from "@chakra-ui/icons";
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionGrid = motion(Grid);
@@ -48,7 +49,7 @@ const PerformancesPage: React.FC = () => {
         const fetchPerformances = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get("http://localhost:8000/perfomances");
+                const response = await axios.get(`${API_URL}/perfomances`);
                 const pastPerformances = response.data.filter((perf: Performance) => perf.afisha === false);
                 setPerformances(pastPerformances);
             } catch (err) {

--- a/frontend/antrakt/src/pages/ProfilePage.tsx
+++ b/frontend/antrakt/src/pages/ProfilePage.tsx
@@ -37,6 +37,7 @@ import axios from 'axios';
 import ImageUpload from '../components/ImageUpload';
 import Navigation from '../components/Navigation';
 import Footer from '../components/Footer';
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionGrid = motion(Grid);
@@ -215,7 +216,7 @@ const ChangePasswordForm: React.FC<{
         }
         setIsSubmitting(true);
         try {
-            await axios.post('http://localhost:8000/password-reset/', { email: email.trim() });
+            await axios.post(`${API_URL}/password-reset/`, { email: email.trim() });
             toast({
                 title: 'Проверьте почту',
                 description: 'Новый пароль отправлен на указанную почту. Войдите с ним и при желании смените в кабинете.',
@@ -292,7 +293,7 @@ export default function ProfilePage() {
     useEffect(() => {
         const fetchMyReviews = async () => {
             try {
-                const res = await axios.get('http://localhost:8000/my/reviews/');
+                const res = await axios.get(`${API_URL}/my/reviews/`);
                 setMyReviews(res.data || []);
             } catch (error) {
                 console.error('Ошибка при загрузке отзывов:', error);
@@ -307,7 +308,7 @@ export default function ProfilePage() {
         const fetchProfile = async () => {
             try {
                 setIsLoading(true);
-                const response = await axios.get(`http://localhost:8000/user${user?.id}/`);
+                const response = await axios.get(`${API_URL}/user${user?.id}/`);
                 setProfile(response.data);
                 setIsLoading(false);
             } catch (error) {
@@ -341,7 +342,7 @@ export default function ProfilePage() {
                 profile_photo: data.profile_photo || profile.profile_photo,
             };
 
-            await axios.put(`http://localhost:8000/user${profile.id}/`, updatedData);
+            await axios.put(`${API_URL}/user${profile.id}/`, updatedData);
 
             updateUser({
                 ...user!,
@@ -359,7 +360,7 @@ export default function ProfilePage() {
 
     const handleDeleteAccount = async () => {
         try {
-            await axios.delete(`http://localhost:8000/user${profile?.id}/`);
+            await axios.delete(`${API_URL}/user${profile?.id}/`);
             logout();
             navigate('/');
             toast({

--- a/frontend/antrakt/src/pages/TeamPage.tsx
+++ b/frontend/antrakt/src/pages/TeamPage.tsx
@@ -25,6 +25,7 @@ import Navigation from "../components/Navigation";
 import { FaTheaterMasks, FaCrown, FaFilm } from "react-icons/fa";
 import { ChevronRightIcon, CalendarIcon } from "@chakra-ui/icons";
 import { yearDeclension, performanceDeclension } from "../utils/declension";
+import { API_URL } from '../config';
 
 // Стилизованные компоненты для иконок
 const CFaTheaterMasks = chakra(FaTheaterMasks as any);
@@ -98,7 +99,7 @@ const TeamPage: React.FC = () => {
                 setLoading(true);
 
                 // Загрузка режиссеров
-                const directorsRes = await axios.get("http://localhost:8000/directors");
+                const directorsRes = await axios.get(`${API_URL}/directors`);
                 const transformedDirectors = directorsRes.data.map((director: ServerDirector, index: number) => ({
                     id: director.id,
                     name: director.name,
@@ -112,7 +113,7 @@ const TeamPage: React.FC = () => {
                 setDirectors(transformedDirectors);
 
                 // Загрузка актеров
-                const actorsRes = await axios.get("http://localhost:8000/actors");
+                const actorsRes = await axios.get(`${API_URL}/actors`);
                 const transformedActors = actorsRes.data.map((actor: ServerActor, index: number) => {
                     const experienceMatch = actor.time_in_theatre.match(/\d+/);
                     const experience = experienceMatch ? parseInt(experienceMatch[0]) : 0;

--- a/frontend/antrakt/src/pages/admin/AchievementsPageAdmin.tsx
+++ b/frontend/antrakt/src/pages/admin/AchievementsPageAdmin.tsx
@@ -41,6 +41,7 @@ import {
 import axios from 'axios';
 import { AchievementForm } from './forms/AchievementForm';
 import DeleteConfirmDialog from '../../components/admin/DeleteConfirmDialog';
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -81,7 +82,7 @@ const AchievementsPageAdmin: React.FC = () => {
 
     const fetchAchievements = async () => {
         try {
-            const response = await axios.get('http://localhost:8000/achievements-admin/');
+            const response = await axios.get(`${API_URL}/achievements-admin/`);
             setAchievements(response.data);
         } catch (error) {
             console.error('Ошибка при загрузке достижений:', error);
@@ -115,7 +116,7 @@ const AchievementsPageAdmin: React.FC = () => {
     const handleHardDelete = async (id: number) => {
         if (!id) return;
         try {
-            await axios.delete(`http://localhost:8000/achievement${id}/?hard=1`);
+            await axios.delete(`${API_URL}/achievement${id}/?hard=1`);
             setAchievements(prev => prev.filter(a => a.id !== id));
             toast({ title: 'Удалено навсегда', description: 'Достижение полностью удалено из базы', status: 'info', duration: 2000, isClosable: true });
         } catch (error) {
@@ -131,7 +132,7 @@ const AchievementsPageAdmin: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/achievement${id}/`, {
+            await axios.put(`${API_URL}/achievement${id}/`, {
                 deleted_at: new Date().toISOString()
             });
             toast({
@@ -168,7 +169,7 @@ const AchievementsPageAdmin: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/achievement${id}/`, {
+            await axios.put(`${API_URL}/achievement${id}/`, {
                 deleted_at: null
             });
             toast({

--- a/frontend/antrakt/src/pages/admin/ActorsPage.tsx
+++ b/frontend/antrakt/src/pages/admin/ActorsPage.tsx
@@ -39,6 +39,7 @@ import {
 import axios from 'axios';
 import { ActorForm } from './forms/ActorForm';
 import DeleteConfirmDialog from '../../components/admin/DeleteConfirmDialog';
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -89,7 +90,7 @@ const ActorsPage: React.FC = () => {
 
     const fetchActors = async () => {
         try {
-            const response = await axios.get('http://localhost:8000/actors-admin/');
+            const response = await axios.get(`${API_URL}/actors-admin/`);
             setActors(response.data);
             setIsLoading(false);
         } catch (error) {
@@ -109,7 +110,7 @@ const ActorsPage: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/actor${id}/`, {
+            await axios.put(`${API_URL}/actor${id}/`, {
                 deleted_at: new Date().toISOString()
             });
             toast({
@@ -145,7 +146,7 @@ const ActorsPage: React.FC = () => {
     const handleHardDeleteActor = async (id: number) => {
         if (!id) return;
         try {
-            await axios.delete(`http://localhost:8000/actor${id}/?hard=1`);
+            await axios.delete(`${API_URL}/actor${id}/?hard=1`);
             toast({
                 title: 'Удалено навсегда',
                 description: 'Актёр полностью удалён из базы',
@@ -173,7 +174,7 @@ const ActorsPage: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/actor${id}/`, {
+            await axios.put(`${API_URL}/actor${id}/`, {
                 deleted_at: null
             });
             toast({

--- a/frontend/antrakt/src/pages/admin/ArchivePageAdmin.tsx
+++ b/frontend/antrakt/src/pages/admin/ArchivePageAdmin.tsx
@@ -41,6 +41,7 @@ import {
 import axios from 'axios';
 import { ArchiveForm } from './forms/ArchiveForm';
 import DeleteConfirmDialog from '../../components/admin/DeleteConfirmDialog';
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -86,7 +87,7 @@ const ArchivePageAdmin: React.FC = () => {
 
     const fetchArchives = async () => {
         try {
-            const response = await axios.get('http://localhost:8000/archive-admin/');
+            const response = await axios.get(`${API_URL}/archive-admin/`);
             setArchives(response.data);
             setIsLoading(false);
         } catch (error) {
@@ -105,7 +106,7 @@ const ArchivePageAdmin: React.FC = () => {
     const handleHardDelete = async () => {
         if (!deleteId) return;
         try {
-            await axios.delete(`http://localhost:8000/archive${deleteId}/?hard=1`);
+            await axios.delete(`${API_URL}/archive${deleteId}/?hard=1`);
             setArchives(archives.filter(a => a.id !== deleteId));
             toast({ title: 'Удалено навсегда', description: 'Запись архива полностью удалена из базы', status: 'info', duration: 2000, isClosable: true });
         } catch (error) {
@@ -121,7 +122,7 @@ const ArchivePageAdmin: React.FC = () => {
         if (!deleteId) return;
 
         try {
-            await axios.put(`http://localhost:8000/archive${deleteId}/`, {
+            await axios.put(`${API_URL}/archive${deleteId}/`, {
                 deleted_at: new Date().toISOString()
             });
             setArchives(archives.map(archive =>
@@ -151,7 +152,7 @@ const ArchivePageAdmin: React.FC = () => {
 
     const handleRestoreArchive = async (id: number) => {
         try {
-            await axios.put(`http://localhost:8000/archive${id}/`, {
+            await axios.put(`${API_URL}/archive${id}/`, {
                 deleted_at: null
             });
             setArchives(archives.map(archive =>

--- a/frontend/antrakt/src/pages/admin/BirthdaysPageAdmin.tsx
+++ b/frontend/antrakt/src/pages/admin/BirthdaysPageAdmin.tsx
@@ -22,13 +22,14 @@ import {
 import { FaPlus, FaTrash, FaSave } from 'react-icons/fa';
 import { chakra } from '@chakra-ui/react';
 import axios from 'axios';
+import { API_URL } from '../../config';
 
 const CFaPlus = chakra(FaPlus as any);
 const CFaTrash = chakra(FaTrash as any);
 const CFaSave = chakra(FaSave as any);
 
 const primaryColor = '#f2f2f2';
-const API = 'http://localhost:8000';
+const API = `${API_URL}`;
 
 interface ActorOption { id: number; name: string; image_url?: string; }
 interface Birthday { id: number; actor: number; actor_name: string; actor_image?: string; birth_date: string; }

--- a/frontend/antrakt/src/pages/admin/Dashboard.tsx
+++ b/frontend/antrakt/src/pages/admin/Dashboard.tsx
@@ -45,6 +45,7 @@ import { PerformanceForm } from './forms/PerformancesForm';
 import { NewsForm } from './forms/NewsForm';
 import { DirectorForm } from './forms/DirectorForm';
 import { AchievementForm } from './forms/AchievementForm';
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionGrid = motion(Grid);
@@ -94,12 +95,12 @@ const Dashboard: React.FC = () => {
     const fetchDashboardData = async () => {
         try {
             const [perfRes, actRes, dirRes, newsRes, achRes, usrRes] = await Promise.all([
-                axios.get('http://localhost:8000/perfomances-admin/'),
-                axios.get('http://localhost:8000/actors/'),
-                axios.get('http://localhost:8000/directors/'),
-                axios.get('http://localhost:8000/news/'),
-                axios.get('http://localhost:8000/achievements/'),
-                axios.get('http://localhost:8000/users/'),
+                axios.get(`${API_URL}/perfomances-admin/`),
+                axios.get(`${API_URL}/actors/`),
+                axios.get(`${API_URL}/directors/`),
+                axios.get(`${API_URL}/news/`),
+                axios.get(`${API_URL}/achievements/`),
+                axios.get(`${API_URL}/users/`),
             ]);
 
             setStats({

--- a/frontend/antrakt/src/pages/admin/DirectorsPage.tsx
+++ b/frontend/antrakt/src/pages/admin/DirectorsPage.tsx
@@ -41,6 +41,7 @@ import {
 import axios from 'axios';
 import { DirectorForm } from './forms/DirectorForm';
 import DeleteConfirmDialog from '../../components/admin/DeleteConfirmDialog';
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -82,7 +83,7 @@ const DirectorsPage: React.FC = () => {
 
     const fetchDirectors = async () => {
         try {
-            const response = await axios.get('http://localhost:8000/directors-admin/');
+            const response = await axios.get(`${API_URL}/directors-admin/`);
             setDirectors(response.data);
             setIsLoading(false);
         } catch (error) {
@@ -101,7 +102,7 @@ const DirectorsPage: React.FC = () => {
     const handleHardDeleteDirector = async (id: number) => {
         if (!id) return;
         try {
-            await axios.delete(`http://localhost:8000/director${id}/?hard=1`);
+            await axios.delete(`${API_URL}/director${id}/?hard=1`);
             setDirectors(prev => prev.filter(d => d.id !== id));
             toast({ title: 'Удалено навсегда', description: 'Режиссёр полностью удалён из базы', status: 'info', duration: 2000, isClosable: true });
         } catch (error) {
@@ -117,7 +118,7 @@ const DirectorsPage: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/director${id}/`, {
+            await axios.put(`${API_URL}/director${id}/`, {
                 deleted_at: new Date().toISOString()
             });
             toast({
@@ -154,7 +155,7 @@ const DirectorsPage: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/director${id}/`, {
+            await axios.put(`${API_URL}/director${id}/`, {
                 deleted_at: null
             });
             toast({

--- a/frontend/antrakt/src/pages/admin/NewsPageAdmin.tsx
+++ b/frontend/antrakt/src/pages/admin/NewsPageAdmin.tsx
@@ -45,6 +45,7 @@ import {
 import axios from 'axios';
 import { NewsForm } from './forms/NewsForm';
 import DeleteConfirmDialog from '../../components/admin/DeleteConfirmDialog';
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -88,7 +89,7 @@ const NewsPageAdmin: React.FC = () => {
 
     const fetchNews = async () => {
         try {
-            const response = await axios.get('http://localhost:8000/news-admin/');
+            const response = await axios.get(`${API_URL}/news-admin/`);
             setNews(response.data);
             setIsLoading(false);
         } catch (error) {
@@ -107,7 +108,7 @@ const NewsPageAdmin: React.FC = () => {
     const handleHardDeleteNews = async () => {
         if (!deleteId) return;
         try {
-            await axios.delete(`http://localhost:8000/news${deleteId}/?hard=1`);
+            await axios.delete(`${API_URL}/news${deleteId}/?hard=1`);
             setNews(prevNews => prevNews.filter(item => item.id !== deleteId));
             toast({ title: 'Удалено навсегда', description: 'Новость полностью удалена из базы', status: 'info', duration: 2000, isClosable: true });
         } catch (error) {
@@ -123,7 +124,7 @@ const NewsPageAdmin: React.FC = () => {
         if (!deleteId) return;
 
         try {
-            await axios.put(`http://localhost:8000/news${deleteId}/`, {
+            await axios.put(`${API_URL}/news${deleteId}/`, {
                 deleted_at: new Date().toISOString()
             });
             toast({
@@ -160,7 +161,7 @@ const NewsPageAdmin: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/news${id}/`, {
+            await axios.put(`${API_URL}/news${id}/`, {
                 deleted_at: null
             });
             toast({

--- a/frontend/antrakt/src/pages/admin/PerformancesPageAdmin.tsx
+++ b/frontend/antrakt/src/pages/admin/PerformancesPageAdmin.tsx
@@ -41,6 +41,7 @@ import {
 import axios from 'axios';
 import { PerformanceForm } from './forms/PerformancesForm';
 import DeleteConfirmDialog from '../../components/admin/DeleteConfirmDialog';
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -93,7 +94,7 @@ const PerformancesPage: React.FC = () => {
 
     const fetchPerformances = async () => {
         try {
-            const response = await axios.get('http://localhost:8000/perfomances-admin/');
+            const response = await axios.get(`${API_URL}/perfomances-admin/`);
             setPerformances(response.data);
             setIsLoading(false);
         } catch (error) {
@@ -112,7 +113,7 @@ const PerformancesPage: React.FC = () => {
     const handleHardDelete = async () => {
         if (!deleteId) return;
         try {
-            await axios.delete(`http://localhost:8000/perfomance${deleteId}/?hard=1`);
+            await axios.delete(`${API_URL}/perfomance${deleteId}/?hard=1`);
             setPerformances(performances.filter(p => p.id !== deleteId));
             toast({ title: 'Удалено навсегда', description: 'Спектакль полностью удалён из базы', status: 'info', duration: 2000, isClosable: true });
         } catch (error) {
@@ -128,7 +129,7 @@ const PerformancesPage: React.FC = () => {
         if (!deleteId) return;
 
         try {
-            await axios.put(`http://localhost:8000/perfomance${deleteId}/`, {
+            await axios.put(`${API_URL}/perfomance${deleteId}/`, {
                 deleted_at: new Date().toISOString()
             });
             setPerformances(performances.map(performance =>
@@ -158,7 +159,7 @@ const PerformancesPage: React.FC = () => {
 
     const handleRestorePerformance = async (id: number) => {
         try {
-            await axios.put(`http://localhost:8000/perfomance${id}/`, {
+            await axios.put(`${API_URL}/perfomance${id}/`, {
                 deleted_at: null
             });
             setPerformances(performances.map(performance =>

--- a/frontend/antrakt/src/pages/admin/ReviewsPageAdmin.tsx
+++ b/frontend/antrakt/src/pages/admin/ReviewsPageAdmin.tsx
@@ -28,8 +28,9 @@ import { motion } from 'framer-motion';
 import { FaTrash, FaExclamationTriangle } from 'react-icons/fa';
 import axios from 'axios';
 import DeleteConfirmDialog from '../../components/admin/DeleteConfirmDialog';
+import { API_URL } from '../../config';
 
-const API = 'http://localhost:8000';
+const API = `${API_URL}`;
 const primaryColor = '#f2f2f2';
 
 const MotionBox = motion(Box);

--- a/frontend/antrakt/src/pages/admin/SiteContentPageAdmin.tsx
+++ b/frontend/antrakt/src/pages/admin/SiteContentPageAdmin.tsx
@@ -19,6 +19,7 @@ import {
 import axios from 'axios';
 import Footer from '../../components/Footer';
 import { SiteContentContext, useSiteContent, SiteContentItem } from '../../contexts/SiteContentContext';
+import { API_URL } from '../../config';
 
 const primaryColor = '#f2f2f2';
 
@@ -32,7 +33,7 @@ const SiteContentPageAdmin: React.FC = () => {
 
     const load = () => {
         setLoading(true);
-        axios.get('http://localhost:8000/site-content/')
+        axios.get(`${API_URL}/site-content/`)
             .then(res => {
                 const data: SiteContentItem[] = res.data || [];
                 setItems(data);
@@ -68,7 +69,7 @@ const SiteContentPageAdmin: React.FC = () => {
     const handleSave = async () => {
         setSaving(true);
         try {
-            await axios.put('http://localhost:8000/site-content/', {
+            await axios.put(`${API_URL}/site-content/`, {
                 items: items.map(i => ({ key: i.key, value: draft[i.key] ?? '' })),
             });
             toast({ title: 'Тексты сайта сохранены', status: 'success', duration: 2500, isClosable: true });

--- a/frontend/antrakt/src/pages/admin/SiteReviewsPageAdmin.tsx
+++ b/frontend/antrakt/src/pages/admin/SiteReviewsPageAdmin.tsx
@@ -23,6 +23,7 @@ import {
 import { FaPlus, FaTrash, FaSave, FaSyncAlt } from 'react-icons/fa';
 import { chakra } from '@chakra-ui/react';
 import axios from 'axios';
+import { API_URL } from '../../config';
 
 const CFaPlus = chakra(FaPlus as any);
 const CFaTrash = chakra(FaTrash as any);
@@ -30,7 +31,7 @@ const CFaSave = chakra(FaSave as any);
 const CFaSync = chakra(FaSyncAlt as any);
 
 const primaryColor = '#f2f2f2';
-const API = 'http://localhost:8000';
+const API = `${API_URL}`;
 
 interface SiteReview {
     id: number;

--- a/frontend/antrakt/src/pages/admin/UsersPage.tsx
+++ b/frontend/antrakt/src/pages/admin/UsersPage.tsx
@@ -34,6 +34,7 @@ import {
 import axios from 'axios';
 import { UserForm } from './forms/UsersForm';
 import DeleteConfirmDialog from '../../components/admin/DeleteConfirmDialog';
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -74,7 +75,7 @@ const UsersPage: React.FC = () => {
 
     const fetchUsers = async () => {
         try {
-            const response = await axios.get('http://localhost:8000/users-admin/');
+            const response = await axios.get(`${API_URL}/users-admin/`);
             setUsers(response.data);
             setIsLoading(false);
         } catch (error) {
@@ -93,7 +94,7 @@ const UsersPage: React.FC = () => {
     const handleHardDeleteUser = async (id: number) => {
         if (!id) return;
         try {
-            await axios.delete(`http://localhost:8000/user${id}/?hard=1`);
+            await axios.delete(`${API_URL}/user${id}/?hard=1`);
             setUsers(prev => prev.filter(u => u.id !== id));
             toast({ title: 'Удалено навсегда', description: 'Пользователь полностью удалён из базы', status: 'info', duration: 2000, isClosable: true });
         } catch (error) {
@@ -109,7 +110,7 @@ const UsersPage: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/user${id}/`, {
+            await axios.put(`${API_URL}/user${id}/`, {
                 deleted_at: new Date().toISOString()
             });
             toast({
@@ -146,7 +147,7 @@ const UsersPage: React.FC = () => {
         if (!id) return;
 
         try {
-            await axios.put(`http://localhost:8000/user${id}/`, {
+            await axios.put(`${API_URL}/user${id}/`, {
                 deleted_at: null
             });
             toast({

--- a/frontend/antrakt/src/pages/admin/forms/AchievementForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/AchievementForm.tsx
@@ -21,6 +21,7 @@ import axios from 'axios';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { chakra } from '@chakra-ui/react';
+import { API_URL } from '../../../config';
 
 const CFaTimes = chakra(FaTimes as any);
 const CFaSave = chakra(FaSave as any);
@@ -101,7 +102,7 @@ export const AchievementForm: React.FC<{
         setIsSubmitting(true);
         try {
             if (achievement.id) {
-                await axios.put(`http://localhost:8000/achievement${achievement.id}/`, {
+                await axios.put(`${API_URL}/achievement${achievement.id}/`, {
                     achievement: achievement.achievement,
                     image_url: achievement.image_url,
                     images_list: achievement.images_list || [],
@@ -115,7 +116,7 @@ export const AchievementForm: React.FC<{
                     isClosable: true,
                 });
             } else {
-                await axios.post('http://localhost:8000/achievements/', {
+                await axios.post(`${API_URL}/achievements/`, {
                     achievement: achievement.achievement,
                     image_url: achievement.image_url,
                     images_list: achievement.images_list || [],

--- a/frontend/antrakt/src/pages/admin/forms/ActorForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/ActorForm.tsx
@@ -35,6 +35,7 @@ import axios from 'axios';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { chakra } from '@chakra-ui/react';
+import { API_URL } from '../../../config';
 
 const MotionTag = motion(Tag);
 const CFaPlus = chakra(FaPlus as any);
@@ -162,7 +163,7 @@ export const ActorForm: React.FC<{
     const handleCreateActor = async () => {
         setIsSubmitting(true);
         try {
-            const response = await axios.post('http://localhost:8000/actors/', currentActor);
+            const response = await axios.post(`${API_URL}/actors/`, currentActor);
             toast({
                 title: 'Успех!',
                 description: 'Актёр успешно добавлен',
@@ -190,7 +191,7 @@ export const ActorForm: React.FC<{
 
         setIsSubmitting(true);
         try {
-            await axios.put(`http://localhost:8000/actor${currentActor.id}/`, currentActor);
+            await axios.put(`${API_URL}/actor${currentActor.id}/`, currentActor);
             toast({
                 title: 'Успех!',
                 description: 'Актёр успешно обновлён',

--- a/frontend/antrakt/src/pages/admin/forms/ArchiveForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/ArchiveForm.tsx
@@ -38,6 +38,7 @@ import axios from 'axios';
 import { chakra, useToast } from '@chakra-ui/react';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
+import { API_URL } from '../../../config';
 
 const MotionButton = motion(Button);
 const MotionBox = motion(Box);
@@ -124,8 +125,8 @@ export const ArchiveForm: React.FC<{
         try {
             const method = currentArchive.id ? 'put' : 'post';
             const url = currentArchive.id
-                ? `http://localhost:8000/archive${currentArchive.id}/`
-                : 'http://localhost:8000/archive/';
+                ? `${API_URL}/archive${currentArchive.id}/`
+                : `${API_URL}/archive/`;
 
             await axios[method](url, currentArchive);
 

--- a/frontend/antrakt/src/pages/admin/forms/DirectorForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/DirectorForm.tsx
@@ -35,6 +35,7 @@ import axios from 'axios';
 import { chakra, useToast } from '@chakra-ui/react';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
+import { API_URL } from '../../../config';
 
 const MotionButton = motion(Button);
 const MotionTag = motion(Tag);
@@ -176,7 +177,7 @@ export const DirectorForm: React.FC<{
     const handleCreateDirector = async () => {
         setIsSubmitting(true);
         try {
-            await axios.post('http://localhost:8000/directors/', currentDirector);
+            await axios.post(`${API_URL}/directors/`, currentDirector);
             toast({
                 title: 'Успех!',
                 description: 'Режиссёр успешно добавлен',
@@ -204,7 +205,7 @@ export const DirectorForm: React.FC<{
 
         setIsSubmitting(true);
         try {
-            await axios.put(`http://localhost:8000/director${currentDirector.id}/`, currentDirector);
+            await axios.put(`${API_URL}/director${currentDirector.id}/`, currentDirector);
             toast({
                 title: 'Успех!',
                 description: 'Режиссёр успешно обновлён',

--- a/frontend/antrakt/src/pages/admin/forms/NewsForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/NewsForm.tsx
@@ -39,6 +39,7 @@ import axios from 'axios';
 import { chakra, useToast } from '@chakra-ui/react';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
+import { API_URL } from '../../../config';
 
 const MotionButton = motion(Button);
 const MotionBox = motion(Box);
@@ -135,7 +136,7 @@ export const NewsForm: React.FC<{
     const handleCreateNews = async () => {
         setIsSubmitting(true);
         try {
-            await axios.post('http://localhost:8000/news/', currentNews);
+            await axios.post(`${API_URL}/news/`, currentNews);
             toast({
                 title: 'Успешно',
                 description: 'Новость создана',
@@ -163,7 +164,7 @@ export const NewsForm: React.FC<{
 
         setIsSubmitting(true);
         try {
-            await axios.put(`http://localhost:8000/news${currentNews.id}/`, currentNews);
+            await axios.put(`${API_URL}/news${currentNews.id}/`, currentNews);
             toast({
                 title: 'Успешно',
                 description: 'Новость обновлена',

--- a/frontend/antrakt/src/pages/admin/forms/PerformancesForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/PerformancesForm.tsx
@@ -47,6 +47,7 @@ import axios from 'axios';
 import { chakra, useToast } from '@chakra-ui/react';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
+import { API_URL } from '../../../config';
 
 const MotionButton = motion(Button);
 const MotionTag = motion(Tag);
@@ -206,12 +207,12 @@ export const PerformanceForm: React.FC<{
 
     useEffect(() => {
         // active=1 — только действующие актёры (выбывшие в списке состава не нужны).
-        axios.get('http://localhost:8000/actors/?active=1')
+        axios.get(`${API_URL}/actors/?active=1`)
             .then(res => setActorOptions(
                 (res.data || []).map((a: any) => ({ id: a.id, name: a.name }))
             ))
             .catch(err => console.error('Не удалось загрузить актёров:', err));
-        axios.get('http://localhost:8000/directors/')
+        axios.get(`${API_URL}/directors/`)
             .then(res => setDirectorOptions(
                 (res.data || []).map((d: any) => ({ id: d.id, name: d.name }))
             ))
@@ -371,7 +372,7 @@ export const PerformanceForm: React.FC<{
     const handleCreatePerformance = async () => {
         setIsSubmitting(true);
         try {
-            await axios.post('http://localhost:8000/perfomances/', currentPerformance);
+            await axios.post(`${API_URL}/perfomances/`, currentPerformance);
             toast({
                 title: 'Успех!',
                 description: 'Спектакль успешно добавлен',
@@ -399,7 +400,7 @@ export const PerformanceForm: React.FC<{
 
         setIsSubmitting(true);
         try {
-            await axios.put(`http://localhost:8000/perfomance${currentPerformance.id}/`, currentPerformance);
+            await axios.put(`${API_URL}/perfomance${currentPerformance.id}/`, currentPerformance);
             toast({
                 title: 'Успех!',
                 description: 'Спектакль успешно обновлён',

--- a/frontend/antrakt/src/pages/admin/forms/UsersForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/UsersForm.tsx
@@ -20,6 +20,7 @@ import { chakra } from '@chakra-ui/react';
 import { FaTimes, FaSave } from 'react-icons/fa';
 import axios from 'axios';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
+import { API_URL } from '../../../config';
 
 const CFaTimes = chakra(FaTimes as any);
 const CFaSave = chakra(FaSave as any);
@@ -128,9 +129,9 @@ export const UserForm: React.FC<UserFormProps> = ({
             }
 
             if (initialData) {
-                await axios.put(`http://localhost:8000/user${initialData.id}/`, userData);
+                await axios.put(`${API_URL}/user${initialData.id}/`, userData);
             } else {
-                await axios.post('http://localhost:8000/users/', userData);
+                await axios.post(`${API_URL}/users/`, userData);
             }
 
             onSuccess();

--- a/frontend/antrakt/src/pages/cards/AchievementDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/AchievementDetail.tsx
@@ -24,6 +24,7 @@ import Navigation from "../../components/Navigation";
 import Footer from "../../components/Footer";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { FaTrophy, FaCalendarAlt } from "react-icons/fa";
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const CFaTrophy = chakra(FaTrophy as any);
@@ -51,7 +52,7 @@ const AchievementDetail: React.FC = () => {
         const fetchAchievement = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get(`http://localhost:8000/achievement${id}/`);
+                const response = await axios.get(`${API_URL}/achievement${id}/`);
                 setAchievement(response.data);
             } catch (err) {
                 setError("Ошибка загрузки достижения");

--- a/frontend/antrakt/src/pages/cards/ActorDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/ActorDetail.tsx
@@ -25,6 +25,7 @@ import ReviewsSection from "../../components/ReviewsSection";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { FaTheaterMasks, FaFilm, FaQuoteLeft, FaUserTie, FaBook, FaUser, FaPaintBrush, FaVideo, FaMusic } from "react-icons/fa";
 import { yearDeclension, performanceDeclension } from "../../utils/declension";
+import { API_URL } from '../../config';
 
 const CFaTheaterMasks = chakra(FaTheaterMasks as any);
 const CFaFilm = chakra(FaFilm as any);
@@ -78,8 +79,8 @@ const ActorDetail: React.FC = () => {
             try {
                 setLoading(true);
                 const [actorResponse, performancesResponse] = await Promise.all([
-                    axios.get(`http://localhost:8000/actor${id}`),
-                    axios.get(`http://localhost:8000/perfomances/`)
+                    axios.get(`${API_URL}/actor${id}`),
+                    axios.get(`${API_URL}/perfomances/`)
                 ]);
 
                 setActor({

--- a/frontend/antrakt/src/pages/cards/ArchiveDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/ArchiveDetail.tsx
@@ -23,6 +23,7 @@ import ReviewsSection from "../../components/ReviewsSection";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { FaProjectDiagram } from "react-icons/fa";
 import { Image as ChakraImage } from "@chakra-ui/react";
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionImage = motion(ChakraImage);
@@ -48,7 +49,7 @@ const ArchiveDetail: React.FC = () => {
         const fetchProject = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get(`http://localhost:8000/archive${id}/`);
+                const response = await axios.get(`${API_URL}/archive${id}/`);
                 setProject(response.data);
             } catch (e) {
                 setError("Ошибка загрузки архива");

--- a/frontend/antrakt/src/pages/cards/DirectorDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/DirectorDetail.tsx
@@ -32,6 +32,7 @@ import ReviewsSection from "../../components/ReviewsSection";
 import Navigation from "../../components/Navigation";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { FaTheaterMasks, FaFilm, FaQuoteLeft, FaUserTie, FaBook, FaUser, FaPaintBrush, FaVideo, FaMusic } from "react-icons/fa";
+import { API_URL } from '../../config';
 
 
 // Стилизованные компоненты для иконок
@@ -130,8 +131,8 @@ const DirectorDetail: React.FC = () => {
 
                 // Загружаем данные режиссёра и список всех спектаклей параллельно
                 const [directorResponse, performancesResponse] = await Promise.all([
-                    axios.get(`http://localhost:8000/director${id}`),
-                    axios.get(`http://localhost:8000/perfomances/`)
+                    axios.get(`${API_URL}/director${id}`),
+                    axios.get(`${API_URL}/perfomances/`)
                 ]);
 
                 setDirector({

--- a/frontend/antrakt/src/pages/cards/NewsDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/NewsDetail.tsx
@@ -31,6 +31,7 @@ import Footer from "../../components/Footer";
 import ReviewsSection from "../../components/ReviewsSection";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import { FaNewspaper, FaCalendarAlt, FaExpand } from "react-icons/fa";
+import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionImage = motion(Image);
@@ -66,7 +67,7 @@ const NewsDetail: React.FC = () => {
         const fetchNews = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get(`http://localhost:8000/news${id}/`);
+                const response = await axios.get(`${API_URL}/news${id}/`);
                 setNews(response.data);
             } catch (err) {
                 setError("Ошибка загрузки новости");

--- a/frontend/antrakt/src/pages/cards/PerfomancesDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/PerfomancesDetail.tsx
@@ -31,6 +31,7 @@ import Footer from "../../components/Footer";
 import ReviewsSection from "../../components/ReviewsSection";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import { FaTheaterMasks, FaFilm, FaUserTie, FaClock, FaUsers, FaExpand } from "react-icons/fa";
+import { API_URL } from '../../config';
 
 // Стилизованные компоненты для иконок
 const CFaTheaterMasks = chakra(FaTheaterMasks as any);
@@ -79,7 +80,7 @@ const PerformanceDetail: React.FC = () => {
         const fetchPerformance = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get(`http://localhost:8000/perfomance${id}`);
+                const response = await axios.get(`${API_URL}/perfomance${id}`);
                 setPerformance({
                     ...response.data,
                     production_team: response.data.production_team || [],

--- a/frontend/antrakt/src/sections/BirthdaySection.tsx
+++ b/frontend/antrakt/src/sections/BirthdaySection.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Box, Container, Heading, Text, Image, VStack } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import axios from 'axios';
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 
@@ -19,7 +20,7 @@ const BirthdaySection: React.FC = () => {
 
     useEffect(() => {
         const load = () => {
-            axios.get('http://localhost:8000/birthday-today/')
+            axios.get(`${API_URL}/birthday-today/`)
                 .then(res => setData(res.data))
                 .catch(() => setData({ active: false }));
         };

--- a/frontend/antrakt/src/sections/Hero.tsx
+++ b/frontend/antrakt/src/sections/Hero.tsx
@@ -1,6 +1,7 @@
 import { Box, Heading, Text, Button, Flex } from "@chakra-ui/react";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { useSiteContent } from "../contexts/SiteContentContext";
+import { MEDIA_URL } from '../config';
 
 const MotionDiv = motion.div;
 
@@ -25,7 +26,7 @@ export default function Hero() {
                     left: 0,
                     width: "100%",
                     height: "100%",
-                    backgroundImage: "url('http://localhost:9000/antrakt-images/Общая.png')",
+                    backgroundImage: "url(`${MEDIA_URL}/antrakt-images/Общая.png`)",
                     backgroundSize: "contain",
                     backgroundPosition: "center",
                     backgroundRepeat: "no-repeat",

--- a/frontend/antrakt/src/sections/NewsSection.tsx
+++ b/frontend/antrakt/src/sections/NewsSection.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { Link as RouterLink } from "react-router-dom";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -26,7 +27,7 @@ export default function NewsSection() {
     useEffect(() => {
         const fetchNews = async () => {
             try {
-                const response = await axios.get<NewsItem[]>("http://localhost:8000/news");
+                const response = await axios.get<NewsItem[]>(`${API_URL}/news`);
                 setNews(response.data);
                 setIsLoading(false);
             } catch (err) {

--- a/frontend/antrakt/src/sections/Perfomances.tsx
+++ b/frontend/antrakt/src/sections/Perfomances.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { Link as RouterLink } from "react-router-dom";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -27,7 +28,7 @@ export default function Performances() {
     useEffect(() => {
         const fetchPerformances = async () => {
             try {
-                const response = await axios.get<Performance[]>("http://localhost:8000/afisha");
+                const response = await axios.get<Performance[]>(`${API_URL}/afisha`);
                 setPerformances(response.data);
                 setIsLoading(false);
             } catch (err) {

--- a/frontend/antrakt/src/sections/Testimonials.tsx
+++ b/frontend/antrakt/src/sections/Testimonials.tsx
@@ -12,6 +12,7 @@ import {
 import { motion } from "framer-motion";
 import { FaQuoteLeft, FaStar } from "react-icons/fa";
 import axios from "axios";
+import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -40,7 +41,7 @@ export default function Testimonials() {
     const [reviews, setReviews] = useState<SiteReview[]>([]);
 
     useEffect(() => {
-        axios.get("http://localhost:8000/site-reviews/")
+        axios.get(`${API_URL}/site-reviews/`)
             .then(res => setReviews(res.data || []))
             .catch(() => setReviews([]));
     }, []);

--- a/frontend/antrakt/src/services/AuthService.ts
+++ b/frontend/antrakt/src/services/AuthService.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
+import { API_URL } from '../config';
 
-const API_BASE_URL = 'http://localhost:8000'; // Адрес Django backend
+const API_BASE_URL = `${API_URL}`; // Адрес Django backend
 
 export interface User {
   id: number;

--- a/frontend/antrakt/src/services/ImageService.ts
+++ b/frontend/antrakt/src/services/ImageService.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
+import { API_URL } from '../config';
 
-const API_BASE_URL = 'http://localhost:8000';
+const API_BASE_URL = `${API_URL}`;
 
 export interface ImageUploadResponse {
     success: boolean;

--- a/frontend/antrakt/src/utils/apiClient.ts
+++ b/frontend/antrakt/src/utils/apiClient.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { getTokens } from './tokenStorage';
+import { API_URL } from '../config';
 
-const API_URL = 'http://127.0.0.1:8000';
 const REFRESH_URL = `${API_URL}/login/`;
 
 // Создаем экземпляр axios с базовой конфигурацией


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<![CDATA[Подготовка проекта к продакшену. Dev-режим не ломается (все прод-настройки — через переменные окружения с dev-дефолтами).

## Backend (settings hardening)
- `SECRET_KEY`, `DEBUG`, `ALLOWED_HOSTS` — из окружения; защита от запуска с dev-ключом при `DEBUG=False`.
- `CORS`/`CSRF` настраиваемые (allow-all только в dev); HTTPS-заголовки безопасности (HSTS, secure-cookies, SSL-redirect) по флагу `SECURE_HTTPS`.
- Статика через **WhiteNoise** (`STATIC_ROOT`, `STORAGES`, `collectstatic`).
- **Убраны реально засветившиеся секреты** из кода (пароль почты, ВК-токен/куки) — теперь только из окружения (их нужно сменить, см. DEPLOYMENT.md).
- Загрузка изображений возвращает публичную ссылку (`MEDIA_URL`), доступную из браузера в проде.

## Frontend (конфиг адресов)
- Добавлен `src/config.ts` (`API_URL`, `MEDIA_URL` из `REACT_APP_*`, дефолт — localhost для dev).
- Заменены **все 84** захардкоженных `http://localhost:8000` / `:9000` в 44 файлах.

## Инфраструктура развёртки
- `backend/Dockerfile.prod` + `entrypoint.sh` (ждёт БД → миграции → collectstatic → gunicorn).
- `frontend/antrakt/Dockerfile.prod` + `nginx.conf` (сборка CRA → nginx, SPA-fallback).
- `docker-compose.prod.yml`: PostgreSQL + MinIO (+ авто-создание бакета с публичным чтением) + backend + frontend + **Caddy** (авто-HTTPS для `DOMAIN`, `api.DOMAIN`, `s3.DOMAIN`).
- `Caddyfile`, `.env.prod.example`, **`DEPLOYMENT.md`**. `.env.prod` в `.gitignore`.

## Что нужно сделать самому (подробно — DEPLOYMENT.md)
1. Сервер с Docker, домен + DNS `A`-записи на `DOMAIN`, `api.DOMAIN`, `s3.DOMAIN`.
2. `cp .env.prod.example .env.prod` → заполнить `SECRET_KEY`, пароли БД/MinIO, **почту** (SMTP-пароль приложения — иначе не приходят код регистрации и новый пароль), при желании ВК-парсер.
3. `docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build`, затем `createsuperuser`.
4. **Сменить ранее засветившиеся секреты** (пароль почты, ВК-токен/куки).

## Тестирование
- `manage.py check --deploy` — без ошибок; `collectstatic` (WhiteNoise) — 197 файлов.
- `npx tsc --noEmit` — без ошибок; в исходниках нет захардкоженных `:8000/:9000`.
- Dev работает после рефактора: home/afisha/team грузят данные, upload возвращает публичный URL.
- `docker-compose.prod.yml` — валидный YAML. Полную сборку образов не запускал (в окружении нет Docker CLI) — сборка на сервере.

Смоук-тест dev после рефактора (данные грузятся):
[Smoke test home](https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprod_smoke_home.webp)
]]>

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9235dd1a-2510-479e-b329-255eda01d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

