### PR TITLE
Fix backend crash: ModuleNotFoundError app.app in production

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,8 +12,11 @@ RUN apt-get update && apt-get install -y \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Копирование исходного кода
+# Копирование исходного кода (backend/ -> /app/).
+# Django-проект лежит в backend/app (manage.py), поэтому рабочая
+# директория — /app/app, а модуль настроек — app.settings.
 COPY . .
+WORKDIR /app/app
 
 # Запуск приложения
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "4", "app.app.wsgi:application"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "4", "app.wsgi:application"]

--- a/backend/app/app/wsgi.py
+++ b/backend/app/app/wsgi.py
@@ -8,14 +8,9 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
 """
 
 import os
-import sys
+
 from django.core.wsgi import get_wsgi_application
 
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.append(BASE_DIR)
-sys.path.append(os.path.join(BASE_DIR, 'my_app1'))
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.app.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
 
 application = get_wsgi_application()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production backend was stuck in a restart loop with:

```
ModuleNotFoundError: No module named 'app.app'
```

`Dockerfile.prod` copies `backend/app/` into `/app`, so Django settings live at `app.settings`. `manage.py` and `asgi.py` already used that path, but `wsgi.py` still pointed at the old `app.app.settings` (and had broken `sys.path` hacks). Gunicorn loads WSGI → Django fails to boot → container restarts forever.

## Changes

- `backend/app/app/wsgi.py`: set `DJANGO_SETTINGS_MODULE` to `app.settings` (same as manage.py/asgi.py); remove obsolete path hacks.
- `backend/Dockerfile`: align WORKDIR/`CMD` with the same module path for local compose.

## After merge — on the VPS

```bash
cd /home/Antrakt
git pull
docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build backend
docker compose --env-file .env.prod -f docker-compose.prod.yml ps
```

Backend should show `Up`, not `Restarting`.

**Note:** public access still needs a real domain (not just an IP) in `DOMAIN` for Caddy HTTPS — see `DEPLOYMENT.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

