### PR TITLE
Fix homepage hero image not loading (MEDIA_URL bug)

### DIFF
--- a/frontend/antrakt/src/sections/Hero.tsx
+++ b/frontend/antrakt/src/sections/Hero.tsx
@@ -26,7 +26,7 @@ export default function Hero() {
                     left: 0,
                     width: "100%",
                     height: "100%",
-                    backgroundImage: "url(`${MEDIA_URL}/antrakt-images/Общая.png`)",
+                    backgroundImage: `url(${MEDIA_URL}/antrakt-images/Общая.png)`,
                     backgroundSize: "contain",
                     backgroundPosition: "center",
                     backgroundRepeat: "no-repeat",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The homepage hero background never loaded because `Hero.tsx` used a double-quoted string:

```js
backgroundImage: "url(`${MEDIA_URL}/antrakt-images/Общая.png`)"
```

`${MEDIA_URL}` was not interpolated, so the browser requested a literal broken URL. Fixed to a template literal (same pattern as `AboutTheatre.tsx`).

## Note for operators

The hero image is hardcoded to MinIO object `antrakt-images/Общая.png` (bucket root). Uploading via the React admin forms (UUID paths under `images/`, `actors/`, etc.) does not change the homepage hero. Place/replace the file as `Общая.png` in the `antrakt-images` bucket.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

