### PR TITLE
Не перенаправлять профиль до загрузки авторизации

### DIFF
--- a/frontend/antrakt/src/pages/ProfilePage.tsx
+++ b/frontend/antrakt/src/pages/ProfilePage.tsx
@@ -298,7 +298,13 @@ const ChangePasswordForm: React.FC<{
 export default function ProfilePage() {
     const navigate = useNavigate();
     const toast = useToast();
-    const { user, isAuthenticated, logout, updateUser } = useAuth();
+    const {
+        user,
+        isAuthenticated,
+        isLoading: isAuthLoading,
+        logout,
+        updateUser
+    } = useAuth();
     const { isOpen: isDeleteModalOpen, onOpen: onDeleteModalOpen, onClose: onDeleteModalClose } = useDisclosure();
     const { isOpen: isEditModalOpen, onOpen: onEditModalOpen, onClose: onEditModalClose } = useDisclosure();
     const { isOpen: isPasswordModalOpen, onOpen: onPasswordModalOpen, onClose: onPasswordModalClose } = useDisclosure();
@@ -340,12 +346,15 @@ export default function ProfilePage() {
             }
         };
 
+        if (isAuthLoading) {
+            return;
+        }
         if (isAuthenticated && user) {
             fetchProfile();
         } else {
             navigate('/');
         }
-    }, [user, isAuthenticated, navigate, toast]);
+    }, [user, isAuthenticated, isAuthLoading, navigate, toast]);
 
     const handleSaveProfile = async (data: Partial<UserProfile>) => {
         if (!profile) return;
@@ -400,7 +409,7 @@ export default function ProfilePage() {
         }
     };
 
-    if (!isAuthenticated) {
+    if (isAuthLoading || !isAuthenticated) {
         return null;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Дополнение к уже смёрженному PR #77: прямой переход на `/profile/:id` больше не отправляет пользователя на главную, пока `AuthContext` ещё восстанавливает сессию.

Проверено:
- `npx tsc --noEmit`
- мобильный прямой переход на `/profile/20`
- regression-тест удаления спектакля у режиссёра повторно проходит
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

