### PR TITLE
Исправить Команду, пол актёров, состояния ошибок и галерею

### DIFF
--- a/backend/app/my_app1/actor_gender.py
+++ b/backend/app/my_app1/actor_gender.py
@@ -1,0 +1,63 @@
+import re
+
+
+ROLE_LABELS = {
+    'male': 'Актёр',
+    'female': 'Актриса',
+}
+
+MALE_GIVEN_NAMES = {
+    'илья', 'никита', 'лука', 'кузьма', 'фома', 'савва', 'данила',
+}
+
+FEMALE_GIVEN_NAMES = {
+    'зайнап', 'гузель', 'гузел', 'любовь', 'нинэль', 'нинель',
+    'рашель', 'эсфирь', 'юдифь',
+}
+
+FEMALE_SURNAME_RE = re.compile(
+    r'(?:ова|ёва|ева|ина|ына|ская|цкая|ая)$',
+    re.IGNORECASE,
+)
+MALE_SURNAME_RE = re.compile(
+    r'(?:ов|ёв|ев|ин|ын|ский|цкий|ой|ый|ий)$',
+    re.IGNORECASE,
+)
+
+
+def infer_actor_gender(full_name):
+    """Infer gender from both given name and surname.
+
+    Names in historical data may be stored as either «Фамилия Имя» or
+    «Имя Фамилия», so every token participates in the decision.
+    """
+    tokens = [
+        token.casefold()
+        for token in re.findall(r"[A-Za-zА-Яа-яЁё-]+", full_name or '')
+        if token
+    ]
+    if not tokens:
+        return 'male'
+
+    if any(token in MALE_GIVEN_NAMES for token in tokens):
+        return 'male'
+    if any(token in FEMALE_GIVEN_NAMES for token in tokens):
+        return 'female'
+
+    # A clearly gendered surname is a strong signal regardless of name order.
+    if any(FEMALE_SURNAME_RE.search(token) for token in tokens):
+        return 'female'
+    if any(MALE_SURNAME_RE.search(token) for token in tokens):
+        return 'male'
+
+    # Typical Russian feminine given names end in «а»/«я». Check all tokens
+    # because old rows do not consistently use the same order.
+    if any(token.endswith(('а', 'я')) for token in tokens):
+        return 'female'
+
+    return 'male'
+
+
+def actor_role_label(full_name, gender_override=None):
+    gender = gender_override or infer_actor_gender(full_name)
+    return ROLE_LABELS.get(gender, ROLE_LABELS['male'])

--- a/backend/app/my_app1/migrations/0018_actors_gender_override.py
+++ b/backend/app/my_app1/migrations/0018_actors_gender_override.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('my_app1', '0017_perfomances_guest_director_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='actors',
+            name='gender_override',
+            field=models.CharField(
+                blank=True,
+                choices=[('male', 'Актёр'), ('female', 'Актриса')],
+                default=None,
+                max_length=10,
+                null=True,
+            ),
+        ),
+    ]

--- a/backend/app/my_app1/models.py
+++ b/backend/app/my_app1/models.py
@@ -120,7 +120,12 @@ class Perfomances(ImageUploadMixin, models.Model): # Спектакли
     ) # Режиссёр спектакля. Имя видно уже в "Афише"; сам спектакль добавляется
       # режиссёру на страницу при переходе в раздел "Спектакли".
     # Если режиссёра нет в базе — имя хранится здесь («Другой(-ая)»).
-    guest_director_name = models.CharField(max_length=100, blank=True, default='')
+    guest_director_name = models.CharField(
+        max_length=100,
+        blank=True,
+        default='',
+        help_text='Имя режиссёра не из базы («Другой(-ая)»).',
+    )
     # Данные для карточки на странице режиссёра (задаются заранее в админке).
     production_title = models.CharField(max_length=200, blank=True, default='')
     # Название постановки; если пусто — берётся название спектакля (title).
@@ -131,6 +136,13 @@ class Perfomances(ImageUploadMixin, models.Model): # Спектакли
 
 
 class Actors(ImageUploadMixin, models.Model):
+    GENDER_MALE = 'male'
+    GENDER_FEMALE = 'female'
+    GENDER_CHOICES = [
+        (GENDER_MALE, 'Актёр'),
+        (GENDER_FEMALE, 'Актриса'),
+    ]
+
     class Meta:
         db_table = 'actors'
     
@@ -138,6 +150,15 @@ class Actors(ImageUploadMixin, models.Model):
     updated_at = models.DateTimeField(null=True)
     deleted_at = models.DateTimeField(null=True, blank=True, default=None)
     name = models.CharField(max_length=50, null=False)
+    # NULL = определять автоматически по имени и фамилии; значение задаётся
+    # администратором только для ручного исправления.
+    gender_override = models.CharField(
+        max_length=10,
+        choices=GENDER_CHOICES,
+        null=True,
+        blank=True,
+        default=None,
+    )
     place_of_work = models.CharField(max_length=200, blank=True) # Место работы
     joined_at = models.DateField(null=True, blank=True) # Когда актёр пришёл в театр (год+месяц)
     left_at = models.DateField(null=True, blank=True) # Когда актёр выбыл (null = активный)

--- a/backend/app/my_app1/serializers.py
+++ b/backend/app/my_app1/serializers.py
@@ -11,6 +11,7 @@ from .models import (User, Perfomances, Actors, DirectorsTheatre,
                      sync_performance_cast_to_actors,
                      sync_actor_roles_to_performances)
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from .actor_gender import actor_role_label
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -284,6 +285,7 @@ class ActorsSerializer(serializers.ModelSerializer):
     # Вычисляемые поля: стаж в студии считается из joined_at/left_at.
     time_in_theatre = serializers.SerializerMethodField()
     is_active = serializers.SerializerMethodField()
+    role_label = serializers.SerializerMethodField()
 
     class Meta:
         model = Actors
@@ -294,6 +296,9 @@ class ActorsSerializer(serializers.ModelSerializer):
 
     def get_is_active(self, obj):
         return obj.is_active
+
+    def get_role_label(self, obj):
+        return actor_role_label(obj.name, obj.gender_override)
 
     def create(self, validated_data):
         with transaction.atomic():

--- a/backend/app/my_app1/tests.py
+++ b/backend/app/my_app1/tests.py
@@ -11,7 +11,8 @@ from my_app1.models import (
     Review, ReviewReaction, DirectorsTheatre, Archive, News,
     EmailVerification, promote_performance,
 )
-from my_app1.serializers import PerfomanceSerializer
+from my_app1.serializers import ActorsSerializer, PerfomanceSerializer
+from my_app1.actor_gender import actor_role_label, infer_actor_gender
 
 
 def make_actor(name='Актёр Тестовый'):
@@ -32,6 +33,32 @@ def make_performance(title='Спектакль', afisha=True, description='Оп�
         description=description,
         afisha=afisha,
     )
+
+
+class ActorGenderTests(TestCase):
+    def test_inference_uses_given_name_and_surname(self):
+        cases = {
+            'Захаров Илья': 'male',
+            'Юсупова Зайнап': 'female',
+            'Умблия Ольга': 'female',
+            'Авдиенко Инна': 'female',
+            'Протченко Татьяна': 'female',
+            'Садртдинова Гузель': 'female',
+            'Гузель Садртдинова': 'female',
+            'Нусс Анастасия': 'female',
+        }
+        for name, expected in cases.items():
+            with self.subTest(name=name):
+                self.assertEqual(infer_actor_gender(name), expected)
+
+    def test_admin_override_wins(self):
+        self.assertEqual(actor_role_label('Захаров Илья', 'female'), 'Актриса')
+        self.assertEqual(actor_role_label('Юсупова Зайнап', 'male'), 'Актёр')
+
+    def test_serializer_exposes_role_label(self):
+        actor = make_actor('Авдиенко Инна')
+        data = ActorsSerializer(actor).data
+        self.assertEqual(data['role_label'], 'Актриса')
 
 
 class PromotePerformanceTests(TestCase):

--- a/frontend/antrakt/src/components/Navigation.tsx
+++ b/frontend/antrakt/src/components/Navigation.tsx
@@ -14,8 +14,10 @@ import {
     MenuButton,
     MenuList,
     MenuItem,
+    usePrefersReducedMotion,
     useToast
 } from "@chakra-ui/react";
+import { motion } from "framer-motion";
 import { CloseIcon, HamburgerIcon } from "@chakra-ui/icons";
 import { useNavigate, Link as RouterLink } from "react-router-dom"; // Добавлен импорт Link as RouterLink
 import AuthModal from "./AuthModal";
@@ -26,6 +28,7 @@ import { useSiteContent } from "../contexts/SiteContentContext";
 const primaryColor = "#f2f2f2";
 const darkBg = "#0a0a0a";
 const lightText = "#ffffff";
+const MotionBox = motion(Box);
 
 const NAV_ITEMS = [
     { label: "Афиша", href: "afisha" },
@@ -39,6 +42,7 @@ const NAV_ITEMS = [
 
 export default function Navigation() {
     const { isOpen, onToggle } = useDisclosure();
+    const prefersReducedMotion = usePrefersReducedMotion();
     const {
         isAuthModalOpen,
         authMode,
@@ -183,16 +187,46 @@ export default function Navigation() {
             >
                 <Box>
                     <Link as={RouterLink} to="/" _hover={{ textDecoration: "none" }}>
-                        <Text
-                            fontSize={{ base: "xl", md: "2xl" }}
-                            fontWeight="bold"
-                            color={lightText}
-                            letterSpacing="widest"
-                            whiteSpace="nowrap"
-                            title={getText('nav.brand_full', 'Норильский народный театр')}
+                        <MotionBox
+                            position="relative"
+                            display="inline-block"
+                            animate={prefersReducedMotion ? undefined : {
+                                scale: [1, 1.035, 1],
+                                filter: [
+                                    "drop-shadow(0 0 4px rgba(255,255,255,0.25))",
+                                    "drop-shadow(0 0 13px rgba(255,255,255,0.75))",
+                                    "drop-shadow(0 0 4px rgba(255,255,255,0.25))",
+                                ],
+                            }}
+                            transition={{
+                                duration: 2.8,
+                                repeat: Infinity,
+                                ease: "easeInOut",
+                            }}
+                            whileHover={{ scale: 1.08 }}
                         >
-                            {getText('nav.logo', 'ННТ')}
-                        </Text>
+                            <Box
+                                position="absolute"
+                                inset="-8px"
+                                borderRadius="lg"
+                                bg="radial-gradient(circle, rgba(255,255,255,0.2) 0%, transparent 72%)"
+                                filter="blur(7px)"
+                                pointerEvents="none"
+                                aria-hidden="true"
+                            />
+                            <Text
+                                position="relative"
+                                zIndex={1}
+                                fontSize={{ base: "xl", md: "2xl" }}
+                                fontWeight="bold"
+                                color={lightText}
+                                letterSpacing="widest"
+                                whiteSpace="nowrap"
+                                title={getText('nav.brand_full', 'Норильский народный театр')}
+                            >
+                                {getText('nav.logo', 'ННТ')}
+                            </Text>
+                        </MotionBox>
                     </Link>
                 </Box>
 

--- a/frontend/antrakt/src/components/PageFetchError.tsx
+++ b/frontend/antrakt/src/components/PageFetchError.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import {
+    Alert,
+    AlertDescription,
+    AlertIcon,
+    AlertTitle,
+    Button,
+} from "@chakra-ui/react";
+
+interface PageFetchErrorProps {
+    message: string;
+    title?: string;
+    onRetry?: () => void;
+}
+
+/**
+ * Единое состояние ошибки загрузки для публичных страниц и секций.
+ */
+const PageFetchError: React.FC<PageFetchErrorProps> = ({
+    message,
+    title = "Ошибка загрузки",
+    onRetry = () => window.location.reload(),
+}) => (
+    <Alert
+        status="error"
+        variant="subtle"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        maxW="lg"
+        mx="auto"
+        borderRadius="xl"
+        bg="rgba(197, 48, 48, 0.12)"
+        border="1px solid"
+        borderColor="red.700"
+        py={8}
+        px={6}
+    >
+        <AlertIcon boxSize="40px" mr={0} />
+        <AlertTitle mt={4} mb={1} fontSize="md" color="white">
+            {title}
+        </AlertTitle>
+        <AlertDescription maxW="sm" color="gray.300" fontSize="sm" textAlign="center">
+            {message}
+        </AlertDescription>
+        <Button mt={4} colorScheme="red" size="sm" onClick={onRetry}>
+            Повторить попытку
+        </Button>
+    </Alert>
+);
+
+export default PageFetchError;

--- a/frontend/antrakt/src/components/PhotoGallery.tsx
+++ b/frontend/antrakt/src/components/PhotoGallery.tsx
@@ -1,0 +1,316 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+    Box,
+    Flex,
+    Heading,
+    IconButton,
+    Image,
+    Modal,
+    ModalCloseButton,
+    ModalContent,
+    ModalOverlay,
+    Text,
+    chakra,
+    useDisclosure,
+} from "@chakra-ui/react";
+import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
+import { AnimatePresence, motion } from "framer-motion";
+import { FaExpand } from "react-icons/fa";
+
+const MotionImage = motion(Image);
+const CFaExpand = chakra(FaExpand as any);
+
+interface PhotoGalleryProps {
+    images: string[];
+    altPrefix: string;
+}
+
+const variants = {
+    enter: (direction: number) => ({
+        x: direction > 0 ? 1000 : -1000,
+        opacity: 0,
+    }),
+    center: { x: 0, opacity: 1 },
+    exit: (direction: number) => ({
+        x: direction > 0 ? -1000 : 1000,
+        opacity: 0,
+    }),
+};
+
+/** Галерея, единая для спектаклей и архивных мероприятий. */
+const PhotoGallery: React.FC<PhotoGalleryProps> = ({ images, altPrefix }) => {
+    const cleanImages = useMemo(() => images.filter(Boolean), [images]);
+    const [galleryIndex, setGalleryIndex] = useState(0);
+    const [currentImageIndex, setCurrentImageIndex] = useState(0);
+    const [direction, setDirection] = useState(1);
+    const [isManualNavigation, setIsManualNavigation] = useState(false);
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    useEffect(() => {
+        cleanImages.forEach((src) => {
+            const img = new window.Image();
+            img.src = src;
+        });
+    }, [cleanImages]);
+
+    useEffect(() => {
+        if (cleanImages.length <= 1 || isManualNavigation || isOpen) {
+            if (intervalRef.current) clearInterval(intervalRef.current);
+            return;
+        }
+        intervalRef.current = setInterval(() => {
+            setDirection(1);
+            setGalleryIndex(prev => (prev + 1) % cleanImages.length);
+        }, 4000);
+        return () => {
+            if (intervalRef.current) clearInterval(intervalRef.current);
+        };
+    }, [cleanImages.length, isManualNavigation, isOpen]);
+
+    useEffect(() => {
+        if (!isManualNavigation) return;
+        const timeout = setTimeout(() => setIsManualNavigation(false), 8000);
+        return () => clearTimeout(timeout);
+    }, [isManualNavigation]);
+
+    if (!cleanImages.length) return null;
+
+    const showImage = (index: number) => {
+        setCurrentImageIndex(index);
+        onOpen();
+    };
+    const galleryPrev = () => {
+        setIsManualNavigation(true);
+        setDirection(-1);
+        setGalleryIndex(prev => (prev - 1 + cleanImages.length) % cleanImages.length);
+    };
+    const galleryNext = () => {
+        setIsManualNavigation(true);
+        setDirection(1);
+        setGalleryIndex(prev => (prev + 1) % cleanImages.length);
+    };
+    const modalPrev = () => {
+        setDirection(-1);
+        setCurrentImageIndex(prev => (prev - 1 + cleanImages.length) % cleanImages.length);
+    };
+    const modalNext = () => {
+        setDirection(1);
+        setCurrentImageIndex(prev => (prev + 1) % cleanImages.length);
+    };
+
+    return (
+        <>
+            <Box mt={16}>
+                <Heading
+                    as="h2"
+                    size="md"
+                    mb={6}
+                    color="white"
+                    textAlign="center"
+                    position="relative"
+                    _after={{
+                        content: '""',
+                        position: "absolute",
+                        bottom: "-8px",
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        width: "60px",
+                        height: "3px",
+                        bg: "#d9d9d9",
+                        borderRadius: "full",
+                    }}
+                >
+                    Фотогалерея
+                </Heading>
+
+                <Flex
+                    position="relative"
+                    align="center"
+                    justify="center"
+                    overflow="hidden"
+                    h={{ base: "250px", md: "400px" }}
+                    w="100%"
+                    borderRadius="xl"
+                    bg="rgba(20, 20, 20, 0.5)"
+                    border="1px solid"
+                    borderColor="rgba(255, 255, 255, 0.15)"
+                    boxShadow="0 5px 20px rgba(0, 0, 0, 0.5)"
+                    p={2}
+                >
+                    <IconButton
+                        aria-label="Предыдущее фото"
+                        icon={<ChevronLeftIcon />}
+                        position="absolute"
+                        left="10px"
+                        zIndex={1}
+                        bg="rgba(0, 0, 0, 0.5)"
+                        color="white"
+                        _hover={{ bg: "#d9d9d9" }}
+                        onClick={galleryPrev}
+                    />
+                    <IconButton
+                        aria-label="Следующее фото"
+                        icon={<ChevronRightIcon />}
+                        position="absolute"
+                        right="10px"
+                        zIndex={1}
+                        bg="rgba(0, 0, 0, 0.5)"
+                        color="white"
+                        _hover={{ bg: "#d9d9d9" }}
+                        onClick={galleryNext}
+                    />
+
+                    <AnimatePresence initial={false} custom={direction}>
+                        <MotionImage
+                            key={galleryIndex}
+                            custom={direction}
+                            variants={variants}
+                            initial="enter"
+                            animate="center"
+                            exit="exit"
+                            transition={{
+                                x: { type: "spring", stiffness: 300, damping: 30 },
+                                opacity: { duration: 0.2 },
+                            }}
+                            src={cleanImages[galleryIndex]}
+                            alt={`${altPrefix} ${galleryIndex + 1}`}
+                            position="absolute"
+                            h="100%"
+                            w="auto"
+                            maxW="100%"
+                            objectFit="contain"
+                            cursor="pointer"
+                            onClick={() => showImage(galleryIndex)}
+                            borderRadius="md"
+                        />
+                    </AnimatePresence>
+
+                    <IconButton
+                        aria-label="Увеличить фото"
+                        icon={<CFaExpand />}
+                        position="absolute"
+                        bottom="10px"
+                        right="10px"
+                        zIndex={1}
+                        bg="rgba(0, 0, 0, 0.5)"
+                        color="white"
+                        _hover={{ bg: "#d9d9d9" }}
+                        onClick={() => showImage(galleryIndex)}
+                    />
+
+                    <Flex
+                        position="absolute"
+                        bottom="10px"
+                        left="50%"
+                        transform="translateX(-50%)"
+                        gap={2}
+                        zIndex={1}
+                    >
+                        {cleanImages.map((_, index) => (
+                            <Box
+                                key={index}
+                                w="10px"
+                                h="10px"
+                                borderRadius="full"
+                                bg={index === galleryIndex ? "#d9d9d9" : "gray.600"}
+                                cursor="pointer"
+                                onClick={() => {
+                                    setIsManualNavigation(true);
+                                    setDirection(index > galleryIndex ? 1 : -1);
+                                    setGalleryIndex(index);
+                                }}
+                                _hover={{ bg: "#d9d9d9" }}
+                            />
+                        ))}
+                    </Flex>
+                </Flex>
+            </Box>
+
+            <Modal
+                isOpen={isOpen}
+                onClose={() => {
+                    onClose();
+                    setIsManualNavigation(false);
+                }}
+                size={{ base: "full", md: "6xl" }}
+                isCentered
+            >
+                <ModalOverlay bg="rgba(0, 0, 0, 0.8)" />
+                <ModalContent bg="transparent" boxShadow="none">
+                    <ModalCloseButton
+                        color="white"
+                        bg="rgba(0, 0, 0, 0.5)"
+                        _hover={{ bg: "#d9d9d9" }}
+                        size="lg"
+                        zIndex="overlay"
+                    />
+                    <Flex position="relative" h={{ base: "80vh", md: "85vh" }} align="center" justify="center">
+                        <IconButton
+                            aria-label="Предыдущее фото"
+                            icon={<ChevronLeftIcon />}
+                            position="absolute"
+                            left="10px"
+                            zIndex={1}
+                            bg="rgba(0, 0, 0, 0.5)"
+                            color="white"
+                            fontSize="xl"
+                            size="lg"
+                            _hover={{ bg: "#d9d9d9" }}
+                            onClick={modalPrev}
+                        />
+                        <IconButton
+                            aria-label="Следующее фото"
+                            icon={<ChevronRightIcon />}
+                            position="absolute"
+                            right="10px"
+                            zIndex={1}
+                            bg="rgba(0, 0, 0, 0.5)"
+                            color="white"
+                            fontSize="xl"
+                            size="lg"
+                            _hover={{ bg: "#d9d9d9" }}
+                            onClick={modalNext}
+                        />
+                        <AnimatePresence initial={false} custom={direction}>
+                            <MotionImage
+                                key={currentImageIndex}
+                                custom={direction}
+                                variants={variants}
+                                initial="enter"
+                                animate="center"
+                                exit="exit"
+                                transition={{
+                                    x: { type: "spring", stiffness: 900, damping: 60 },
+                                    opacity: { duration: 0.15 },
+                                }}
+                                src={cleanImages[currentImageIndex]}
+                                alt={`${altPrefix} ${currentImageIndex + 1}`}
+                                maxH="85vh"
+                                maxW="100%"
+                                objectFit="contain"
+                                borderRadius="md"
+                            />
+                        </AnimatePresence>
+                        <Text
+                            position="absolute"
+                            bottom="20px"
+                            left="50%"
+                            transform="translateX(-50%)"
+                            color="white"
+                            bg="rgba(0, 0, 0, 0.5)"
+                            px={3}
+                            py={1}
+                            borderRadius="md"
+                            zIndex={1}
+                        >
+                            {currentImageIndex + 1} / {cleanImages.length}
+                        </Text>
+                    </Flex>
+                </ModalContent>
+            </Modal>
+        </>
+    );
+};
+
+export default PhotoGallery;

--- a/frontend/antrakt/src/pages/AchievementsPage.tsx
+++ b/frontend/antrakt/src/pages/AchievementsPage.tsx
@@ -1,9 +1,5 @@
 import React, { useState, useEffect } from "react";
 import {
-    Alert,
-    AlertDescription,
-    AlertIcon,
-    AlertTitle,
     Box,
     Button,
     Flex,
@@ -18,6 +14,7 @@ import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
+import PageFetchError from "../components/PageFetchError";
 import axios from "axios";
 import { API_URL } from '../config';
 
@@ -74,28 +71,7 @@ const AchievementsPage: React.FC = () => {
             <Box minH="100vh" bg="#0a0a0a" display="flex" flexDirection="column">
                 <Navigation />
                 <Flex flex="1" align="center" justify="center" px={4} py={{ base: 12, md: 20 }}>
-                    <Alert
-                        status="error"
-                        variant="subtle"
-                        flexDirection="column"
-                        alignItems="center"
-                        maxW="lg"
-                        borderRadius="xl"
-                        bg="rgba(197, 48, 48, 0.12)"
-                        border="1px solid"
-                        borderColor="red.700"
-                    >
-                        <AlertIcon boxSize="40px" mr={0} />
-                        <AlertTitle mt={4} mb={1} fontSize="md" color="white">
-                            Ошибка загрузки
-                        </AlertTitle>
-                        <AlertDescription maxW="sm" color="gray.300" fontSize="sm" textAlign="center">
-                            {error}
-                        </AlertDescription>
-                        <Button mt={4} colorScheme="red" size="sm" onClick={() => window.location.reload()}>
-                            Повторить попытку
-                        </Button>
-                    </Alert>
+                    <PageFetchError message={error} />
                 </Flex>
                 <Footer />
             </Box>

--- a/frontend/antrakt/src/pages/AfishaPage.tsx
+++ b/frontend/antrakt/src/pages/AfishaPage.tsx
@@ -11,16 +11,13 @@ import {
     GridItem,
     Flex,
     Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
     Container,
     Badge // Добавлено для отображения типа записи
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
+import PageFetchError from "../components/PageFetchError";
 import { ChevronRightIcon } from "@chakra-ui/icons";
 import { API_URL } from '../config';
 
@@ -83,16 +80,8 @@ const AfishaPage: React.FC = () => {
         return (
             <Box>
                 <Navigation />
-                <Box textAlign="center" py={{ base: 12, md: 20 }} bg="black">
-                    <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                        <AlertIcon boxSize="40px" mr={0} />
-                        <AlertTitle mt={4} mb={1} fontSize="md" color="white">
-                            Ошибка загрузки
-                        </AlertTitle>
-                        <AlertDescription maxWidth="sm" color="gray.400" fontSize="sm">
-                            {error}
-                        </AlertDescription>
-                    </Alert>
+                <Box py={{ base: 12, md: 20 }} px={4} bg="black">
+                    <PageFetchError message={error} />
                 </Box>
                 <Footer />
             </Box>

--- a/frontend/antrakt/src/pages/ArchivePage.tsx
+++ b/frontend/antrakt/src/pages/ArchivePage.tsx
@@ -8,10 +8,6 @@ import {
     Image,
     Flex,
     Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
     Container,
     Grid,
     GridItem
@@ -19,6 +15,7 @@ import {
 import { motion } from "framer-motion";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
+import PageFetchError from "../components/PageFetchError";
 import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
@@ -80,16 +77,8 @@ const ArchivePage: React.FC = () => {
         return (
             <Box>
                 <Navigation />
-                <Box textAlign="center" py={{ base: 12, md: 20 }} bg="black">
-                    <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                        <AlertIcon boxSize="40px" mr={0} />
-                        <AlertTitle mt={4} mb={1} fontSize="md" color="white">
-                            Ошибка загрузки
-                        </AlertTitle>
-                        <AlertDescription maxWidth="sm" color="gray.400" fontSize="sm">
-                            {error}
-                        </AlertDescription>
-                    </Alert>
+                <Box py={{ base: 12, md: 20 }} px={4} bg="black">
+                    <PageFetchError message={error} />
                 </Box>
                 <Footer />
             </Box>

--- a/frontend/antrakt/src/pages/NewsPage.tsx
+++ b/frontend/antrakt/src/pages/NewsPage.tsx
@@ -9,11 +9,7 @@ import {
     Heading,
     Skeleton,
     Flex,
-    Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription
+    Spinner
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import { format } from "date-fns";
@@ -22,6 +18,7 @@ import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
+import PageFetchError from "../components/PageFetchError";
 import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
@@ -158,16 +155,8 @@ const NewsPage: React.FC = () => {
                     </MotionBox>
 
                     {error ? (
-                        <Box textAlign="center" py={10}>
-                            <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                                <AlertIcon boxSize="40px" mr={0} />
-                                <AlertTitle mt={4} mb={1} fontSize="md" color={lightText}>
-                                    Ошибка загрузки
-                                </AlertTitle>
-                                <AlertDescription maxWidth="sm" color={grayText} fontSize="sm">
-                                    {error}
-                                </AlertDescription>
-                            </Alert>
+                        <Box py={10}>
+                            <PageFetchError message={error} />
                         </Box>
                     ) : isLoading ? (
                         <Flex justify="center" align="center" minH="300px">

--- a/frontend/antrakt/src/pages/PerformancesPage.tsx
+++ b/frontend/antrakt/src/pages/PerformancesPage.tsx
@@ -11,15 +11,12 @@ import {
     GridItem,
     Flex,
     Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
     Container
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
+import PageFetchError from "../components/PageFetchError";
 import { ChevronRightIcon } from "@chakra-ui/icons";
 import { API_URL } from '../config';
 
@@ -79,16 +76,8 @@ const PerformancesPage: React.FC = () => {
         return (
             <Box>
                 <Navigation />
-                <Box textAlign="center" py={{ base: 12, md: 20 }} bg="black">
-                    <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                        <AlertIcon boxSize="40px" mr={0} />
-                        <AlertTitle mt={4} mb={1} fontSize="md" color="white">
-                            Ошибка загрузки
-                        </AlertTitle>
-                        <AlertDescription maxWidth="sm" color="gray.400" fontSize="sm">
-                            {error}
-                        </AlertDescription>
-                    </Alert>
+                <Box py={{ base: 12, md: 20 }} px={4} bg="black">
+                    <PageFetchError message={error} />
                 </Box>
                 <Footer />
             </Box>

--- a/frontend/antrakt/src/pages/ProfilePage.tsx
+++ b/frontend/antrakt/src/pages/ProfilePage.tsx
@@ -37,6 +37,7 @@ import axios from 'axios';
 import ImageUpload from '../components/ImageUpload';
 import Navigation from '../components/Navigation';
 import Footer from '../components/Footer';
+import PageFetchError from '../components/PageFetchError';
 import { API_URL } from '../config';
 
 const MotionBox = motion(Box);
@@ -311,6 +312,7 @@ export default function ProfilePage() {
     const [isLoading, setIsLoading] = useState(true);
     const [profile, setProfile] = useState<UserProfile | null>(null);
     const [myReviews, setMyReviews] = useState<any[]>([]);
+    const [profileError, setProfileError] = useState('');
 
     useEffect(() => {
         const fetchMyReviews = async () => {
@@ -330,11 +332,13 @@ export default function ProfilePage() {
         const fetchProfile = async () => {
             try {
                 setIsLoading(true);
+                setProfileError('');
                 const response = await axios.get(`${API_URL}/user${user?.id}/`);
                 setProfile(response.data);
                 setIsLoading(false);
             } catch (error) {
                 console.error('Ошибка при загрузке профиля:', error);
+                setProfileError('Не удалось загрузить данные профиля');
                 toast({
                     title: 'Ошибка',
                     description: 'Не удалось загрузить данные профиля',
@@ -411,6 +415,18 @@ export default function ProfilePage() {
 
     if (isAuthLoading || !isAuthenticated) {
         return null;
+    }
+
+    if (profileError) {
+        return (
+            <Box bg="black" minH="100vh" display="flex" flexDirection="column">
+                <Navigation />
+                <Flex flex="1" align="center" justify="center" px={4} py={{ base: 12, md: 20 }}>
+                    <PageFetchError message={profileError} />
+                </Flex>
+                <Footer />
+            </Box>
+        );
     }
 
     return (

--- a/frontend/antrakt/src/pages/TeamPage.tsx
+++ b/frontend/antrakt/src/pages/TeamPage.tsx
@@ -1,10 +1,6 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import {
-    Alert,
-    AlertIcon,
-    AlertDescription,
-    AlertTitle,
     Box,
     Grid,
     GridItem,
@@ -22,10 +18,10 @@ import { motion } from "framer-motion";
 import Footer from "../components/Footer";
 import { useNavigate } from "react-router-dom";
 import Navigation from "../components/Navigation";
+import PageFetchError from "../components/PageFetchError";
 import { FaTheaterMasks, FaCrown, FaFilm } from "react-icons/fa";
 import { ChevronRightIcon, CalendarIcon } from "@chakra-ui/icons";
 import { yearDeclension, performanceDeclension } from "../utils/declension";
-import { getActorRoleLabel } from "../utils/actorRoleLabel";
 import { API_URL } from '../config';
 
 // Стилизованные компоненты для иконок
@@ -71,6 +67,7 @@ interface ServerActor {
     perfomances: string[] | null;
     role_in_perfomances: string[] | null;
     image_url: string;
+    role_label: "Актёр" | "Актриса";
 }
 
 const TeamPage: React.FC = () => {
@@ -121,7 +118,7 @@ const TeamPage: React.FC = () => {
                     return {
                         id: actor.id,
                         name: actor.name,
-                        role: getActorRoleLabel(actor.name),
+                        role: actor.role_label,
                         experience,
                         productions: actor.perfomances?.length || 0,
                         isDirector: false,
@@ -154,19 +151,8 @@ const TeamPage: React.FC = () => {
         return (
             <Box>
                 <Navigation />
-                <Box textAlign="center" py={20} bg="black">
-                    <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                        <AlertIcon boxSize="40px" mr={0} />
-                        <AlertTitle mt={4} mb={1} fontSize="md" color="white">
-                            Ошибка загрузки
-                        </AlertTitle>
-                        <AlertDescription maxWidth="sm" color="gray.400" fontSize="sm">
-                            {error}
-                        </AlertDescription>
-                        <Button mt={4} colorScheme="red" size="sm" onClick={() => window.location.reload()}>
-                            Повторить попытку
-                        </Button>
-                    </Alert>
+                <Box py={20} px={4} bg="black">
+                    <PageFetchError message={error} />
                 </Box>
                 <Footer />
             </Box>
@@ -179,6 +165,7 @@ const TeamPage: React.FC = () => {
     const renderActorCard = (actor: TeamMember) => (
         <MotionGridItem
             key={actor.id}
+            minW="0"
             variants={{
                 hidden: { opacity: 0, scale: 0.8 },
                 visible: { opacity: 1, scale: 1, transition: { duration: 0.5 } }
@@ -263,23 +250,35 @@ const TeamPage: React.FC = () => {
         <Box minH="100vh" bg="black" display="flex" flexDirection="column" overflowX="hidden">
             <Navigation />
 
-            <Box flex="1" py={{ base: 12, md: 20 }} px={{ base: 4, md: 8 }} position="relative">
+            <Box
+                flex="1"
+                py={{ base: 12, md: 20 }}
+                px={{ base: 4, md: 8 }}
+                position="relative"
+                overflow="hidden"
+            >
                 {/* Декоративный элемент */}
                 <MotionBox
                     position="absolute"
-                    bottom="-20%"
-                    left="-10%"
-                    w={{ base: "320px", md: "500px" }}
-                    h={{ base: "320px", md: "500px" }}
-                    bg={primaryColor}
+                    top="-10%"
+                    right="-10%"
+                    w="400px"
+                    h="400px"
+                    bg="linear-gradient(135deg, #2a2a2a, #151515)"
                     borderRadius="full"
                     filter="blur(80px)"
-                    opacity={0.15}
+                    opacity={0.2}
                     animate={{ scale: [1, 1.1, 1] }}
                     transition={{ duration: 6, repeat: Infinity, repeatType: "reverse" }}
+                    pointerEvents="none"
                 />
 
-                <Container maxW="container.xl" position="relative" zIndex="1">
+                <Container
+                    maxW="container.xl"
+                    position="relative"
+                    zIndex="1"
+                    px={{ base: 0, md: 4 }}
+                >
                     {/* Заголовок страницы */}
                     <MotionBox
                         initial={{ opacity: 0, y: 20 }}
@@ -364,6 +363,7 @@ const TeamPage: React.FC = () => {
                             {directors.map((director) => (
                                 <MotionGridItem
                                     key={director.id}
+                                    minW="0"
                                     variants={{
                                         hidden: { opacity: 0, y: 30 },
                                         visible: { opacity: 1, y: 0, transition: { duration: 0.6 } }

--- a/frontend/antrakt/src/pages/admin/forms/ActorForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/ActorForm.tsx
@@ -37,6 +37,10 @@ import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { chakra } from '@chakra-ui/react';
 import { API_URL } from '../../../config';
+import {
+    ActorGender,
+    getActorRoleLabel,
+} from '../../../utils/actorRoleLabel';
 
 const MotionTag = motion(Tag);
 const CFaPlus = chakra(FaPlus as any);
@@ -71,6 +75,8 @@ interface Actor {
     perfomances: string[];
     role_in_perfomances: string[];
     image_url: string;
+    gender_override: ActorGender | null;
+    role_label?: "Актёр" | "Актриса";
     deleted_at?: string | null;
 }
 
@@ -102,6 +108,7 @@ export const ActorForm: React.FC<{
         author_song: [],
         perfomances: [],
         role_in_perfomances: [],
+        gender_override: null,
         deleted_at: null
     });
     const [listInputs, setListInputs] = useState<Record<string, string>>({});
@@ -305,6 +312,43 @@ export const ActorForm: React.FC<{
                             borderColor="#444444"
                             _hover={{ borderColor: '#555555' }}
                         />
+                    </FormControl>
+
+                    <FormControl>
+                        <FormLabel display="flex" alignItems="center" gap={2}>
+                            <CFaUser color={primaryColor} />
+                            <Text as="span" fontWeight="semibold">
+                                Подпись на сайте
+                            </Text>
+                        </FormLabel>
+                        <Select
+                            value={currentActor.gender_override || ''}
+                            onChange={(e) => setCurrentActor(prev => ({
+                                ...prev,
+                                gender_override: (e.target.value || null) as ActorGender | null,
+                            }))}
+                            focusBorderColor={primaryColor}
+                            bg="#333333"
+                            borderColor="#444444"
+                            _hover={{ borderColor: '#555555' }}
+                        >
+                            <option value="" style={{ backgroundColor: '#333333', color: 'white' }}>
+                                Автоматически
+                            </option>
+                            <option value="male" style={{ backgroundColor: '#333333', color: 'white' }}>
+                                Актёр
+                            </option>
+                            <option value="female" style={{ backgroundColor: '#333333', color: 'white' }}>
+                                Актриса
+                            </option>
+                        </Select>
+                        <Text mt={1} fontSize="sm" color="#AAAAAA">
+                            Сейчас: {getActorRoleLabel(
+                                currentActor.name || '',
+                                currentActor.gender_override,
+                            )}. Если автоматическое определение ошиблось,
+                            выберите значение вручную.
+                        </Text>
                     </FormControl>
 
                     <FormControl>

--- a/frontend/antrakt/src/pages/cards/AchievementDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/AchievementDetail.tsx
@@ -12,16 +12,13 @@ import {
     Button,
     chakra,
     Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
     VStack,
     SimpleGrid
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import Navigation from "../../components/Navigation";
 import Footer from "../../components/Footer";
+import PageFetchError from "../../components/PageFetchError";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { FaTrophy, FaCalendarAlt } from "react-icons/fa";
 import { API_URL } from '../../config';
@@ -77,19 +74,12 @@ const AchievementDetail: React.FC = () => {
 
     if (error) {
         return (
-            <Box textAlign="center" py={{ base: 12, md: 20 }} bg="black">
-                <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                    <AlertIcon boxSize="40px" mr={0} />
-                    <AlertTitle mt={4} mb={1} fontSize="md" color="white">
-                        Ошибка загрузки
-                    </AlertTitle>
-                    <AlertDescription maxWidth="sm" color="gray.400" fontSize="sm">
-                        {error}
-                    </AlertDescription>
-                    <Button mt={4} colorScheme="red" size="sm" onClick={() => window.location.reload()}>
-                        Повторить попытку
-                    </Button>
-                </Alert>
+            <Box minH="100vh" bg="black">
+                <Navigation />
+                <Box py={{ base: 12, md: 20 }} px={4}>
+                    <PageFetchError message={error} />
+                </Box>
+                <Footer />
             </Box>
         );
     }

--- a/frontend/antrakt/src/pages/cards/ActorDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/ActorDetail.tsx
@@ -12,20 +12,16 @@ import {
     Flex,
     Button,
     chakra,
-    Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription
+    Spinner
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import Navigation from "../../components/Navigation";
 import Footer from "../../components/Footer";
 import ReviewsSection from "../../components/ReviewsSection";
+import PageFetchError from "../../components/PageFetchError";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { FaTheaterMasks, FaFilm, FaQuoteLeft, FaUserTie, FaBook, FaUser, FaPaintBrush, FaVideo, FaMusic } from "react-icons/fa";
 import { yearDeclension, performanceDeclension } from "../../utils/declension";
-import { getActorRoleLabel } from "../../utils/actorRoleLabel";
 import { API_URL } from '../../config';
 
 const CFaTheaterMasks = chakra(FaTheaterMasks as any);
@@ -56,6 +52,7 @@ interface ServerActor {
     author_song: string[] | null;
     perfomances: string[] | null;
     role_in_perfomances: string[] | null;
+    role_label: "Актёр" | "Актриса";
 }
 
 interface Performance {
@@ -129,12 +126,12 @@ const ActorDetail: React.FC = () => {
 
     if (error) {
         return (
-            <Box textAlign="center" py={{ base: 12, md: 20 }} bg="black">
-                <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                    <AlertIcon boxSize="40px" mr={0} />
-                    <AlertTitle mt={4} mb={1} fontSize="md" color="white">Ошибка загрузки</AlertTitle>
-                    <AlertDescription maxWidth="sm" color="gray.400" fontSize="sm">{error}</AlertDescription>
-                </Alert>
+            <Box minH="100vh" bg="black">
+                <Navigation />
+                <Box py={{ base: 12, md: 20 }} px={4}>
+                    <PageFetchError message={error} />
+                </Box>
+                <Footer />
             </Box>
         );
     }
@@ -159,8 +156,6 @@ const ActorDetail: React.FC = () => {
 
     const experienceMatch = actor.time_in_theatre.match(/\d+/);
     const experience = experienceMatch ? parseInt(experienceMatch[0]) : 0;
-    const roleLabel = getActorRoleLabel(actor.name);
-
     return (
         <Box bg="black" display="flex" flexDirection="column" minH="100vh">
             <Navigation />
@@ -220,7 +215,7 @@ const ActorDetail: React.FC = () => {
                         <GridItem minW="0">
                             <VStack align="start" spacing={6} sx={{ wordBreak: "break-word", overflowWrap: "anywhere" }}>
                                 <Heading as="h1" size="lg" color="white">{actor.name}</Heading>
-                                <Text color="whiteAlpha.800" fontSize="sm">{roleLabel}</Text>
+                                <Text color="whiteAlpha.800" fontSize="sm">{actor.role_label}</Text>
 
                                 <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={6} w="full">
                                     <VStack align="start">

--- a/frontend/antrakt/src/pages/cards/ArchiveDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/ArchiveDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import {
@@ -10,32 +10,22 @@ import {
     GridItem,
     Button,
     Container,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
-    Flex,
-    IconButton,
-    Modal,
-    ModalOverlay,
-    ModalContent,
-    ModalCloseButton,
-    useDisclosure,
     chakra
 } from "@chakra-ui/react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import Navigation from "../../components/Navigation";
 import Footer from "../../components/Footer";
 import ReviewsSection from "../../components/ReviewsSection";
-import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
-import { FaProjectDiagram, FaExpand } from "react-icons/fa";
+import PhotoGallery from "../../components/PhotoGallery";
+import PageFetchError from "../../components/PageFetchError";
+import { ChevronLeftIcon } from "@chakra-ui/icons";
+import { FaProjectDiagram } from "react-icons/fa";
 import { Image as ChakraImage } from "@chakra-ui/react";
 import { API_URL } from '../../config';
 
 const MotionBox = motion(Box);
 const MotionImage = motion(ChakraImage);
 const CFaProject = chakra(FaProjectDiagram as any);
-const CFaExpand = chakra(FaExpand as any);
 
 interface ArchiveProject {
     id: number;
@@ -53,10 +43,6 @@ const ArchiveDetail: React.FC = () => {
     const [project, setProject] = useState<ArchiveProject | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
-    const [galleryIndex, setGalleryIndex] = useState(0);
-    const [direction, setDirection] = useState(1);
-    const { isOpen, onOpen, onClose } = useDisclosure();
-    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     useEffect(() => {
         const fetchProject = async () => {
@@ -77,17 +63,6 @@ const ArchiveDetail: React.FC = () => {
 
     const gallery = project?.images_list?.filter(Boolean) || [];
 
-    useEffect(() => {
-        if (gallery.length <= 1) return;
-        intervalRef.current = setInterval(() => {
-            setDirection(1);
-            setGalleryIndex(prev => (prev + 1) % gallery.length);
-        }, 5000);
-        return () => {
-            if (intervalRef.current) clearInterval(intervalRef.current);
-        };
-    }, [gallery.length]);
-
     if (loading) {
         return (
             <Box bg="#0a0a0a" minH="100vh" display="flex" flexDirection="column">
@@ -104,12 +79,8 @@ const ArchiveDetail: React.FC = () => {
         return (
             <Box bg="#0a0a0a" minH="100vh" display="flex" flexDirection="column">
                 <Navigation />
-                <Box textAlign="center" py={{ base: 12, md: 20 }} bg="#0a0a0a">
-                    <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                        <AlertIcon boxSize="40px" mr={0} />
-                        <AlertTitle mt={4} mb={1} fontSize="md" color="#e0e0e0">Ошибка загрузки</AlertTitle>
-                        <AlertDescription maxWidth="sm" color="#a0a0a0" fontSize="sm">{error}</AlertDescription>
-                    </Alert>
+                <Box py={{ base: 12, md: 20 }} px={4} bg="#0a0a0a">
+                    <PageFetchError message={error} />
                 </Box>
                 <Footer />
             </Box>
@@ -190,107 +161,13 @@ const ArchiveDetail: React.FC = () => {
                         </GridItem>
                     </Grid>
 
-                    {gallery.length > 0 && (
-                        <Box mt={16}>
-                            <Heading
-                                as="h2"
-                                size="md"
-                                mb={6}
-                                color="white"
-                                textAlign="center"
-                            >
-                                Фотогалерея
-                            </Heading>
-
-                            <Flex
-                                position="relative"
-                                align="center"
-                                justify="center"
-                                overflow="hidden"
-                                h={{ base: "250px", md: "400px" }}
-                                w="100%"
-                            >
-                                {gallery.length > 1 && (
-                                    <IconButton
-                                        aria-label="Назад"
-                                        icon={<ChevronLeftIcon />}
-                                        position="absolute"
-                                        left={2}
-                                        zIndex={2}
-                                        onClick={() => {
-                                            setDirection(-1);
-                                            setGalleryIndex(prev => (prev - 1 + gallery.length) % gallery.length);
-                                        }}
-                                    />
-                                )}
-                                <AnimatePresence mode="wait" custom={direction}>
-                                    <MotionBox
-                                        key={galleryIndex}
-                                        custom={direction}
-                                        initial={{ opacity: 0, x: direction * 40 }}
-                                        animate={{ opacity: 1, x: 0 }}
-                                        exit={{ opacity: 0, x: direction * -40 }}
-                                        transition={{ duration: 0.35 }}
-                                        position="relative"
-                                    >
-                                        <ChakraImage
-                                            src={gallery[galleryIndex]}
-                                            alt={`Фото ${galleryIndex + 1}`}
-                                            maxH={{ base: "230px", md: "380px" }}
-                                            objectFit="contain"
-                                            borderRadius="md"
-                                            cursor="pointer"
-                                            onClick={onOpen}
-                                        />
-                                        <IconButton
-                                            aria-label="Открыть"
-                                            icon={<CFaExpand />}
-                                            size="sm"
-                                            position="absolute"
-                                            top={2}
-                                            right={2}
-                                            onClick={onOpen}
-                                        />
-                                    </MotionBox>
-                                </AnimatePresence>
-                                {gallery.length > 1 && (
-                                    <IconButton
-                                        aria-label="Вперёд"
-                                        icon={<ChevronRightIcon />}
-                                        position="absolute"
-                                        right={2}
-                                        zIndex={2}
-                                        onClick={() => {
-                                            setDirection(1);
-                                            setGalleryIndex(prev => (prev + 1) % gallery.length);
-                                        }}
-                                    />
-                                )}
-                            </Flex>
-                        </Box>
-                    )}
+                    <PhotoGallery images={gallery} altPrefix={`Фото: ${project.title}`} />
 
                     {project.afisha === false && (
                         <ReviewsSection type="archive" targetId={Number(id)} />
                     )}
                 </Container>
             </Box>
-
-            <Modal isOpen={isOpen} onClose={onClose} size="6xl" isCentered>
-                <ModalOverlay />
-                <ModalContent bg="transparent" boxShadow="none" maxW="90vw">
-                    <ModalCloseButton color="white" />
-                    {gallery[galleryIndex] && (
-                        <ChakraImage
-                            src={gallery[galleryIndex]}
-                            alt="Фото"
-                            maxH="90vh"
-                            objectFit="contain"
-                            mx="auto"
-                        />
-                    )}
-                </ModalContent>
-            </Modal>
 
             <Footer />
         </Box>

--- a/frontend/antrakt/src/pages/cards/DirectorDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/DirectorDetail.tsx
@@ -13,10 +13,6 @@ import {
     Button,
     chakra,
     Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
     Modal,
     ModalOverlay,
     ModalContent,
@@ -30,6 +26,7 @@ import { motion } from "framer-motion";
 import Footer from "../../components/Footer";
 import ReviewsSection from "../../components/ReviewsSection";
 import Navigation from "../../components/Navigation";
+import PageFetchError from "../../components/PageFetchError";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { FaTheaterMasks, FaFilm, FaQuoteLeft, FaUserTie, FaBook, FaUser, FaPaintBrush, FaVideo, FaMusic } from "react-icons/fa";
 import { API_URL } from '../../config';
@@ -166,19 +163,12 @@ const DirectorDetail: React.FC = () => {
 
     if (error) {
         return (
-            <Box textAlign="center" py={{ base: 12, md: 20 }} bg="black">
-                <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                    <AlertIcon boxSize="40px" mr={0} />
-                    <AlertTitle mt={4} mb={1} fontSize="md" color="white">
-                        Ошибка загрузки
-                    </AlertTitle>
-                    <AlertDescription maxWidth="sm" color="gray.400" fontSize="sm">
-                        {error}
-                    </AlertDescription>
-                    <Button mt={4} colorScheme="red" size="sm" onClick={() => window.location.reload()}>
-                        Повторить попытку
-                    </Button>
-                </Alert>
+            <Box minH="100vh" bg="black">
+                <Navigation />
+                <Box py={{ base: 12, md: 20 }} px={4}>
+                    <PageFetchError message={error} />
+                </Box>
+                <Footer />
             </Box>
         );
     }

--- a/frontend/antrakt/src/pages/cards/NewsDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/NewsDetail.tsx
@@ -13,10 +13,6 @@ import {
     Button,
     chakra,
     Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
     Modal,
     ModalOverlay,
     ModalContent,
@@ -29,6 +25,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import Navigation from "../../components/Navigation";
 import Footer from "../../components/Footer";
 import ReviewsSection from "../../components/ReviewsSection";
+import PageFetchError from "../../components/PageFetchError";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import { FaNewspaper, FaCalendarAlt, FaExpand } from "react-icons/fa";
 import { API_URL } from '../../config';
@@ -152,16 +149,8 @@ const NewsDetail: React.FC = () => {
         return (
             <Box>
                 <Navigation />
-                <Box textAlign="center" py={{ base: 12, md: 20 }} bg="black">
-                    <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                        <AlertIcon boxSize="40px" mr={0} />
-                        <AlertTitle mt={4} mb={1} fontSize="md" color="#e0e0e0">
-                            Ошибка загрузки
-                        </AlertTitle>
-                        <AlertDescription maxWidth="sm" color="#a0a0a0" fontSize="sm">
-                            {error}
-                        </AlertDescription>
-                    </Alert>
+                <Box py={{ base: 12, md: 20 }} px={4} bg="black">
+                    <PageFetchError message={error} />
                 </Box>
                 <Footer />
             </Box>

--- a/frontend/antrakt/src/pages/cards/PerfomancesDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/PerfomancesDetail.tsx
@@ -13,10 +13,6 @@ import {
     Button,
     chakra,
     Spinner,
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
     Modal,
     ModalOverlay,
     ModalContent,
@@ -29,6 +25,7 @@ import { motion, AnimatePresence } from "framer-motion"; // Добавлен Ani
 import Navigation from "../../components/Navigation";
 import Footer from "../../components/Footer";
 import ReviewsSection from "../../components/ReviewsSection";
+import PageFetchError from "../../components/PageFetchError";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import { FaTheaterMasks, FaFilm, FaUserTie, FaClock, FaUsers, FaExpand } from "react-icons/fa";
 import { API_URL } from '../../config';
@@ -222,16 +219,8 @@ const PerformanceDetail: React.FC = () => {
         return (
             <Box>
                 <Navigation />
-                <Box textAlign="center" py={{ base: 12, md: 20 }} bg="black">
-                    <Alert status="error" variant="subtle" flexDirection="column" alignItems="center">
-                        <AlertIcon boxSize="40px" mr={0} />
-                        <AlertTitle mt={4} mb={1} fontSize="md" color="white">
-                            Ошибка загрузки
-                        </AlertTitle>
-                        <AlertDescription maxWidth="sm" color="gray.400" fontSize="sm">
-                            {error}
-                        </AlertDescription>
-                    </Alert>
+                <Box py={{ base: 12, md: 20 }} px={4} bg="black">
+                    <PageFetchError message={error} />
                 </Box>
                 <Footer />
             </Box>

--- a/frontend/antrakt/src/sections/BirthdaySection.tsx
+++ b/frontend/antrakt/src/sections/BirthdaySection.tsx
@@ -3,6 +3,7 @@ import { Box, Container, Heading, Text, Image, VStack } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import axios from 'axios';
 import { API_URL } from '../config';
+import PageFetchError from '../components/PageFetchError';
 
 const MotionBox = motion(Box);
 
@@ -17,12 +18,14 @@ interface BirthdayData {
 
 const BirthdaySection: React.FC = () => {
     const [data, setData] = useState<BirthdayData | null>(null);
+    const [error, setError] = useState('');
 
     useEffect(() => {
         const load = () => {
+            setError('');
             axios.get(`${API_URL}/birthday-today/`)
                 .then(res => setData(res.data))
-                .catch(() => setData({ active: false }));
+                .catch(() => setError('Не удалось загрузить информацию об именинниках'));
         };
         load();
 
@@ -35,6 +38,14 @@ const BirthdaySection: React.FC = () => {
         const timer = setTimeout(load, nextMidnight.getTime() - now.getTime());
         return () => clearTimeout(timer);
     }, []);
+
+    if (error) {
+        return (
+            <Box as="section" bg="#0a0a0a" py={{ base: 12, md: 16 }} px={4}>
+                <PageFetchError message={error} />
+            </Box>
+        );
+    }
 
     if (!data?.active) return null;
 

--- a/frontend/antrakt/src/sections/NewsSection.tsx
+++ b/frontend/antrakt/src/sections/NewsSection.tsx
@@ -1,9 +1,10 @@
-import { Box, Heading, Grid, GridItem, Text, Button, Image, Flex, Tag, Spinner, Center, useToast } from "@chakra-ui/react";
+import { Box, Heading, Grid, GridItem, Text, Button, Image, Flex, Tag, Spinner, Center } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import { Link as RouterLink } from "react-router-dom";
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { API_URL } from '../config';
+import PageFetchError from "../components/PageFetchError";
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -22,7 +23,6 @@ export default function NewsSection() {
     const [news, setNews] = useState<NewsItem[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    const toast = useToast();
 
     useEffect(() => {
         const fetchNews = async () => {
@@ -35,13 +35,6 @@ export default function NewsSection() {
                 setError("Не удалось загрузить новости");
                 setIsLoading(false);
 
-                toast({
-                    title: "Ошибка",
-                    description: "Не удалось загрузить данные новостей",
-                    status: "error",
-                    duration: 5000,
-                    isClosable: true,
-                });
             }
         };
 
@@ -118,11 +111,9 @@ export default function NewsSection() {
                         <Spinner size="xl" color="#d9d9d9" thickness="4px" />
                     </Center>
                 ) : error ? (
-                    <Center py={10}>
-                        <Text color="red.400" fontSize="xl">
-                            {error}
-                        </Text>
-                    </Center>
+                    <Box py={10}>
+                        <PageFetchError message={error} />
+                    </Box>
                 ) : news.length === 0 ? (
                     <Center py={10}>
                         <Text color="gray.400" fontSize="xl">

--- a/frontend/antrakt/src/sections/Perfomances.tsx
+++ b/frontend/antrakt/src/sections/Perfomances.tsx
@@ -1,9 +1,10 @@
-import { Box, Heading, Grid, GridItem, Text, Button, Image, Flex, Spinner, Center, useToast } from "@chakra-ui/react";
+import { Box, Heading, Grid, GridItem, Text, Button, Image, Flex, Spinner, Center } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import { Link as RouterLink } from "react-router-dom";
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { API_URL } from '../config';
+import PageFetchError from "../components/PageFetchError";
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -23,7 +24,6 @@ export default function Performances() {
     const [performances, setPerformances] = useState<Performance[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    const toast = useToast();
 
     useEffect(() => {
         const fetchPerformances = async () => {
@@ -36,13 +36,6 @@ export default function Performances() {
                 setError("Не удалось загрузить данные спектаклей");
                 setIsLoading(false);
 
-                toast({
-                    title: "Ошибка",
-                    description: "Не удалось загрузить данные спектаклей",
-                    status: "error",
-                    duration: 5000,
-                    isClosable: true,
-                });
             }
         };
 
@@ -114,11 +107,9 @@ export default function Performances() {
                         <Spinner size="xl" color="brand.500" thickness="4px" />
                     </Center>
                 ) : error ? (
-                    <Center py={10}>
-                        <Text color="red.400" fontSize="xl">
-                            {error}
-                        </Text>
-                    </Center>
+                    <Box py={10}>
+                        <PageFetchError message={error} />
+                    </Box>
                 ) : performances.length === 0 ? (
                     <Center py={10}>
                         <Text color="gray.400" fontSize="xl">

--- a/frontend/antrakt/src/sections/Testimonials.tsx
+++ b/frontend/antrakt/src/sections/Testimonials.tsx
@@ -13,6 +13,7 @@ import { motion } from "framer-motion";
 import { FaQuoteLeft, FaStar } from "react-icons/fa";
 import axios from "axios";
 import { API_URL } from '../config';
+import PageFetchError from "../components/PageFetchError";
 
 const MotionBox = motion(Box);
 const MotionGridItem = motion(GridItem);
@@ -39,12 +40,21 @@ const formatDate = (iso?: string | null) => {
 
 export default function Testimonials() {
     const [reviews, setReviews] = useState<SiteReview[]>([]);
+    const [error, setError] = useState("");
 
     useEffect(() => {
         axios.get(`${API_URL}/site-reviews/`)
             .then(res => setReviews(res.data || []))
-            .catch(() => setReviews([]));
+            .catch(() => setError("Не удалось загрузить отзывы зрителей"));
     }, []);
+
+    if (error) {
+        return (
+            <Box py={{ base: 12, md: 20 }} px={4} bg="black">
+                <PageFetchError message={error} />
+            </Box>
+        );
+    }
 
     // Пока отзывов нет — секцию не показываем.
     if (!reviews.length) return null;

--- a/frontend/antrakt/src/utils/actorRoleLabel.ts
+++ b/frontend/antrakt/src/utils/actorRoleLabel.ts
@@ -1,13 +1,37 @@
-/**
- * Russian actor role label inferred from the surname (the first name token).
- *
- * Looking at the full display name is incorrect: male names such as «Илья»
- * end in «я», while female names such as «Зайнап» do not. In this project
- * names are stored as «Фамилия Имя», so the surname is the useful signal.
- */
-export const getActorRoleLabel = (fullName: string): "Актёр" | "Актриса" => {
-    const surname = fullName.trim().split(/\s+/)[0] || "";
-    return /(?:ова|ева|ёва|ина|ына|ская|цкая|ая)$/i.test(surname)
+export type ActorGender = "male" | "female";
+export type ActorRoleLabel = "Актёр" | "Актриса";
+
+const maleGivenNames = new Set([
+    "илья", "никита", "лука", "кузьма", "фома", "савва", "данила",
+]);
+
+const femaleGivenNames = new Set([
+    "зайнап", "гузель", "гузел", "любовь", "нинэль", "нинель",
+    "рашель", "эсфирь", "юдифь",
+]);
+
+const tokenize = (fullName: string): string[] =>
+    fullName.toLocaleLowerCase("ru-RU").match(/[a-zа-яё-]+/gi) || [];
+
+export const inferActorGender = (fullName: string): ActorGender => {
+    const tokens = tokenize(fullName);
+    if (tokens.some((token) => maleGivenNames.has(token))) return "male";
+    if (tokens.some((token) => femaleGivenNames.has(token))) return "female";
+
+    if (tokens.some((token) => /(?:ова|ёва|ева|ина|ына|ская|цкая|ая)$/i.test(token))) {
+        return "female";
+    }
+    if (tokens.some((token) => /(?:ов|ёв|ев|ин|ын|ский|цкий|ой|ый|ий)$/i.test(token))) {
+        return "male";
+    }
+    if (tokens.some((token) => /[ая]$/i.test(token))) return "female";
+    return "male";
+};
+
+export const getActorRoleLabel = (
+    fullName: string,
+    genderOverride?: ActorGender | null,
+): ActorRoleLabel =>
+    (genderOverride || inferActorGender(fullName)) === "female"
         ? "Актриса"
         : "Актёр";
-};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что изменено
- Страница «Команда» повторяет рабочую схему остальных списков: декоративный фон закреплён сверху и клиппится внутри контента, карточки защищены `minW=0`, контейнер адаптивен без горизонтального/вертикального побочного overflow.
- Логотип «ННТ» получил мягкую пульсацию, свечение и hover, с учётом `prefers-reduced-motion`.
- Новый единый `PageFetchError` применён ко всем публичным спискам, detail-страницам, профилю и динамическим секциям главной.
- В `Actors` добавлен nullable `gender_override` (миграция `0018`), а API возвращает вычисленный `role_label`. Определение учитывает все токены имени/фамилии, порядок слов и исключения; админ может оставить «Автоматически» или вручную выбрать «Актёр»/«Актриса».
- Галерея Архива вынесена в полноценный `PhotoGallery` с теми же рамкой, анимацией, автопрокруткой, точками, стрелками и полноэкранным просмотром, что у Спектаклей.

## Проверки
- `npx tsc --noEmit`
- `npx eslint src --ext .js,.jsx,.ts,.tsx` — 0 ошибок (существующие предупреждения)
- `python manage.py test my_app1.tests.ActorGenderTests my_app1.tests.DirectorPromotionTests.test_deleting_performance_removes_it_from_director`
- `python manage.py makemigrations --check --dry-run`
- Ручная проверка Team desktop/mobile, единого offline error-state и actor override без сохранения.

## Demo
[actor_gender_override_clean_demo.mp4](https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factor_gender_override_clean_demo.mp4)

[Автоматическое определение пола актёра](https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factor_gender_auto.webp)
[Единое состояние ошибки загрузки](https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_error_state.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

