### PR TITLE
Center directors, afisha return hold, nav avatar, news dates

### DIFF
--- a/backend/app/my_app1/migrations/0021_perfomances_afisha_hold.py
+++ b/backend/app/my_app1/migrations/0021_perfomances_afisha_hold.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('my_app1', '0020_update_birthday_greeting_placeholders'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='perfomances',
+            name='afisha_hold',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/app/my_app1/models.py
+++ b/backend/app/my_app1/models.py
@@ -104,6 +104,9 @@ class Perfomances(ImageUploadMixin, models.Model): # Спектакли
     director_propagated = models.BooleanField(default=False) # Был ли спектакль уже добавлен на страницу
                                                              # режиссёра (отдельный флаг, чтобы работал
                                                              # "докат", если режиссёра задали позже).
+    # После ручного возврата в «Афишу» без будущих показов авто-промоут не должен
+    # сразу вернуть спектакль в «Спектакли». Снимается, когда появляется будущий показ.
+    afisha_hold = models.BooleanField(default=False)
     image_url = models.URLField(null=False, blank=True)
     performances_image = models.URLField(null=True, blank=True) # Изображение для раздела "Спектакли"
     images_list = ArrayField(
@@ -585,6 +588,7 @@ def promote_performance(performance):
         # Спектакль становится прошедшим — состав должен появиться у актёров.
         perf.afisha = False
         perf.roles_propagated = True
+        perf.afisha_hold = False
         # Билеты больше не нужны: спектакль уже сыгран.
         perf.ticket_url = None
 
@@ -626,7 +630,7 @@ def promote_performance(performance):
         perf.afisha = False
         perf.updated_at = timezone.now()
         perf.save(update_fields=[
-            'afisha', 'roles_propagated', 'director_propagated',
+            'afisha', 'roles_propagated', 'director_propagated', 'afisha_hold',
             'ticket_url', 'updated_at',
         ])
         # Ссылки на билеты у отдельных показов тоже очищаем.
@@ -638,6 +642,30 @@ def promote_performance(performance):
         return perf
 
 
+def refresh_afisha_hold(performance):
+    """Обновить afisha_hold: держать в афише, пока нет будущих показов.
+
+    Нужно, чтобы ручной возврат прошедшего спектакля в «Афишу» не отменялся
+    сразу же вызовом promote_past_performances(). Как только появляется будущий
+    показ — hold снимается, и после его окончания сработает обычный автоперенос.
+    """
+    if not performance.afisha:
+        if performance.afisha_hold:
+            performance.afisha_hold = False
+            performance.updated_at = timezone.now()
+            performance.save(update_fields=['afisha_hold', 'updated_at'])
+        return performance
+
+    now = timezone.now()
+    has_future = performance.shows.filter(show_datetime__gt=now).exists()
+    hold = not has_future
+    if performance.afisha_hold != hold:
+        performance.afisha_hold = hold
+        performance.updated_at = timezone.now()
+        performance.save(update_fields=['afisha_hold', 'updated_at'])
+    return performance
+
+
 def promote_past_performances():
     """Перевести все спектакли, у которых последний показ уже прошёл."""
     from django.db.models import Max
@@ -645,7 +673,7 @@ def promote_past_performances():
     now = timezone.now()
     candidates = (
         Perfomances.objects
-        .filter(afisha=True, deleted_at__isnull=True)
+        .filter(afisha=True, deleted_at__isnull=True, afisha_hold=False)
         .annotate(last_show=Max('shows__show_datetime'))
         .filter(last_show__isnull=False, last_show__lte=now)
         .order_by('id')

--- a/backend/app/my_app1/serializers.py
+++ b/backend/app/my_app1/serializers.py
@@ -10,7 +10,8 @@ from .models import (User, Perfomances, Actors, DirectorsTheatre,
                      SiteReview,
                      sync_performance_cast_to_actors,
                      sync_actor_roles_to_performances,
-                     coalesce_actor_performance_arrays)
+                     coalesce_actor_performance_arrays,
+                     refresh_afisha_hold)
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from .actor_gender import actor_role_label
 
@@ -251,6 +252,7 @@ class PerfomanceSerializer(serializers.ModelSerializer):
             performance = Perfomances.objects.create(**validated_data)
             self._sync_shows(performance, shows_data)
             self._sync_cast(performance, cast_data)
+            refresh_afisha_hold(performance)
             # Синхронизируем состав с карточками актёров (для afisha=False).
             sync_performance_cast_to_actors(performance)
         return performance
@@ -261,6 +263,7 @@ class PerfomanceSerializer(serializers.ModelSerializer):
         if 'director' in validated_data and validated_data.get('director') is not None:
             validated_data['guest_director_name'] = ''
         with transaction.atomic():
+            previous_afisha = instance.afisha
             # Актёры, состоявшие в спектакле до изменения, — чтобы корректно
             # убрать роль у тех, кого удалили из состава.
             previous_actor_ids = list(
@@ -269,6 +272,10 @@ class PerfomanceSerializer(serializers.ModelSerializer):
             )
             for attr, value in validated_data.items():
                 setattr(instance, attr, value)
+            # Ручной возврат в «Афишу»: роли снова раздадутся при следующем
+            # автопереносе в «Спектакли».
+            if instance.afisha and not previous_afisha:
+                instance.roles_propagated = False
             instance.save()
             # Полная замена дочерних записей при их наличии в запросе.
             if shows_data is not None:
@@ -277,6 +284,7 @@ class PerfomanceSerializer(serializers.ModelSerializer):
             if cast_data is not None:
                 instance.cast_members.all().delete()
                 self._sync_cast(instance, cast_data)
+            refresh_afisha_hold(instance)
             sync_performance_cast_to_actors(instance, previous_actor_ids)
         return instance
 

--- a/backend/app/my_app1/tests.py
+++ b/backend/app/my_app1/tests.py
@@ -12,6 +12,7 @@ from my_app1.models import (
     Perfomances, Actors, PerformanceShow, PerformanceCast, User,
     Review, ReviewReaction, DirectorsTheatre, Archive, News,
     Achievements, EmailVerification, promote_performance,
+    promote_past_performances, refresh_afisha_hold,
 )
 from my_app1.serializers import ActorsSerializer, PerfomanceSerializer
 from my_app1.actor_gender import actor_role_label, infer_actor_gender
@@ -693,3 +694,82 @@ class MultiRoleCastSyncTests(TestCase):
 
         data = ActorsSerializer(actor).data
         self.assertEqual(data['perfomances'].count(perf.title), 1)
+
+
+class ReturnToAfishaTests(TestCase):
+    def setUp(self):
+        self.now = timezone.now()
+        self.client = APIClient()
+        self.admin = User.objects.create(
+            email='afisha-admin@test.com', is_superuser=True, is_staff=True,
+            phone_number='+7-000-000-00-99', profile_photo='',
+        )
+        self.admin.set_password('Teatr2026!')
+        self.admin.save()
+        self.client.force_authenticate(user=self.admin)
+
+    def test_manual_return_to_afisha_stays_despite_past_shows(self):
+        actor = make_actor()
+        perf = make_performance(afisha=False, title='Возврат в афишу')
+        PerformanceShow.objects.create(
+            performance=perf, show_datetime=self.now - timedelta(days=3)
+        )
+        PerformanceCast.objects.create(performance=perf, actor=actor, role='Роль')
+        promote_performance(perf)
+        actor.refresh_from_db()
+        self.assertIn(perf.title, actor.perfomances)
+
+        resp = self.client.put(
+            f'/perfomance{perf.id}/',
+            {
+                'title': perf.title,
+                'author': perf.author,
+                'genre': perf.genre,
+                'age_limit': perf.age_limit,
+                'description': perf.description,
+                'afisha': True,
+                'shows': [{
+                    'show_datetime': (self.now - timedelta(days=3)).isoformat(),
+                }],
+                'cast': [{
+                    'actor': actor.id,
+                    'role': 'Роль',
+                    'actor_name': actor.name,
+                }],
+            },
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 200, resp.data)
+        perf.refresh_from_db()
+        self.assertTrue(perf.afisha)
+        self.assertTrue(perf.afisha_hold)
+        self.assertFalse(perf.roles_propagated)
+
+        # Авто-промоут не должен сразу выкинуть спектакль обратно.
+        promote_past_performances()
+        perf.refresh_from_db()
+        self.assertTrue(perf.afisha)
+
+        actor.refresh_from_db()
+        self.assertNotIn(perf.title, actor.perfomances or [])
+
+    def test_future_show_clears_hold_and_allows_promote(self):
+        perf = make_performance(afisha=True, title='С будущим показом')
+        PerformanceShow.objects.create(
+            performance=perf, show_datetime=self.now - timedelta(days=1)
+        )
+        refresh_afisha_hold(perf)
+        perf.refresh_from_db()
+        self.assertTrue(perf.afisha_hold)
+
+        PerformanceShow.objects.create(
+            performance=perf, show_datetime=self.now + timedelta(days=2)
+        )
+        refresh_afisha_hold(perf)
+        perf.refresh_from_db()
+        self.assertFalse(perf.afisha_hold)
+
+        # Пока есть будущий показ — не продвигаем.
+        promote_past_performances()
+        perf.refresh_from_db()
+        self.assertTrue(perf.afisha)

--- a/backend/app/my_app1/views.py
+++ b/backend/app/my_app1/views.py
@@ -432,7 +432,8 @@ class VerifyTokenView(APIView):
                 "id": request.user.id,
                 "email": request.user.email,
                 "phone_number": request.user.phone_number,
-                "is_superuser": request.user.is_superuser
+                "is_superuser": request.user.is_superuser,
+                "profile_photo": request.user.profile_photo or '',
             }
         })
 

--- a/frontend/antrakt/src/components/Navigation.tsx
+++ b/frontend/antrakt/src/components/Navigation.tsx
@@ -282,6 +282,7 @@ export default function Navigation() {
                                 <Avatar
                                     size="sm"
                                     name={user?.email || "User"}
+                                    src={user?.profile_photo || undefined}
                                     bg={primaryColor}
                                     color="#0a0a0a"
                                     cursor="pointer"

--- a/frontend/antrakt/src/pages/TeamPage.tsx
+++ b/frontend/antrakt/src/pages/TeamPage.tsx
@@ -348,10 +348,17 @@ const TeamPage: React.FC = () => {
                         <MotionGrid
                             templateColumns={{
                                 base: "1fr",
-                                md: directors.length === 1 ? "minmax(260px, 450px)" : "repeat(2, 1fr)"
+                                // 1 режиссёр — одна колонка по центру; 2+ — по две в ряд.
+                                md: directors.length === 1
+                                    ? "minmax(260px, 450px)"
+                                    : "repeat(2, minmax(260px, 450px))"
                             }}
                             gap={8}
-                            justifyContent="center" // Центрирование карточек
+                            justifyContent="center"
+                            justifyItems="center"
+                            w="100%"
+                            maxW="960px"
+                            mx="auto"
                             initial="hidden"
                             animate="visible"
                             variants={{
@@ -366,6 +373,8 @@ const TeamPage: React.FC = () => {
                                 <MotionGridItem
                                     key={director.id}
                                     minW="0"
+                                    w="100%"
+                                    maxW="450px"
                                     variants={{
                                         hidden: { opacity: 0, y: 30 },
                                         visible: { opacity: 1, y: 0, transition: { duration: 0.6 } }
@@ -387,7 +396,7 @@ const TeamPage: React.FC = () => {
                                         transition={{
                                             duration: 0.3
                                         }}
-                                        maxWidth="450px" // Уменьшение ширины карточки
+                                        w="100%"
                                         h="100%"
                                         display="flex"
                                         flexDirection="column"

--- a/frontend/antrakt/src/sections/NewsSection.tsx
+++ b/frontend/antrakt/src/sections/NewsSection.tsx
@@ -16,7 +16,7 @@ interface NewsItem {
     title: string;
     image_url: string;
     summary: string;
-    date_publish: string;
+    date_publish: string | null;
     description: string;
 }
 
@@ -43,7 +43,8 @@ export default function NewsSection() {
     }, []);
 
     // Функция для форматирования даты
-    const formatDate = (dateString: string) => {
+    const formatDate = (dateString: string | null | undefined) => {
+        if (!dateString) return '';
         const date = new Date(dateString);
         const options: Intl.DateTimeFormatOptions = {
             day: 'numeric',
@@ -172,7 +173,7 @@ export default function NewsSection() {
     );
 }
 
-function NewsCard({ news, formatDate }: { news: NewsItem; formatDate: (date: string) => string }) {
+function NewsCard({ news, formatDate }: { news: NewsItem; formatDate: (date: string | null | undefined) => string }) {
     return (
         <MotionBox
             bg="rgba(25, 25, 25, 0.8)"
@@ -213,9 +214,11 @@ function NewsCard({ news, formatDate }: { news: NewsItem; formatDate: (date: str
             </Box>
 
             <Box p={6} flex="1" display="flex" flexDirection="column">
-                <Text color="gray.400" fontSize="sm" mb={2}>
-                    {formatDate(news.date_publish)}
-                </Text>
+                {news.date_publish && (
+                    <Text color="gray.400" fontSize="sm" mb={2}>
+                        {formatDate(news.date_publish)}
+                    </Text>
+                )}
 
                 <Heading as="h3" fontSize="xl" color="white" mb={4} lineHeight="tall">
                     {news.title}

--- a/frontend/antrakt/src/services/AuthService.ts
+++ b/frontend/antrakt/src/services/AuthService.ts
@@ -8,7 +8,7 @@ export interface User {
   email: string;
   phone_number: string;
   is_superuser: boolean;
-  profile_photo: string;
+  profile_photo?: string | null;
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Team / directors:** cards are centered — one director centered, two in a centered row, three+ wrap two per row.
- **Afisha toggle:** returning a performance from «Спектакли» to «Афиша» now sticks. Root cause was `promote_past_performances()` immediately flipping past shows back. Added `afisha_hold` (cleared when a future show appears) and reset `roles_propagated` so cast is hidden on Afisha and re-applied after the next auto-promote.
- **Nav avatar:** `token/verify` now returns `profile_photo`; Navigation Avatar uses `src={user.profile_photo}`.
- **News dates:** logic/DB are fine — in the seed DB 2 of 3 news rows have `date_publish = NULL`. UI no longer shows a fake epoch date when the field is empty.

## Test plan
- [ ] Team page: 1 / 2 / 3+ directors — layout centered as described on mobile and desktop.
- [ ] Admin: open a past performance, toggle «В Афише», leave admin — it stays on Afisha; cast hidden; after adding a future show and when it passes — auto-move back to «Спектакли» with roles.
- [ ] Upload profile photo, leave profile — avatar appears top-right (not just a letter).
- [ ] News: confirm published items with `date_publish` show a date; null dates show no misleading date.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

