### PR TITLE
Fix admin creates blocked by empty optional fields

### DIFF
--- a/backend/app/my_app1/models.py
+++ b/backend/app/my_app1/models.py
@@ -25,11 +25,13 @@ class CustomUserManager(BaseUserManager):
     def create_user(self, password, email=None, phone_number=None, **extra_fields):
         if not email and not phone_number:
             raise ValueError('Пользователь должен иметь email или номер телефона')
-        
+
         email_normalized = self.normalize_email(email) if email else None
+        # Пустая строка и NULL эквивалентны «телефона нет» (unique допускает много NULL).
+        phone_normalized = phone_number or None
         user = self.model(
             email=email_normalized,
-            phone_number=phone_number,
+            phone_number=phone_normalized,
             **extra_fields
         )
         user.set_password(password)

--- a/backend/app/my_app1/serializers.py
+++ b/backend/app/my_app1/serializers.py
@@ -16,8 +16,24 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from .actor_gender import actor_role_label
 
 
-class UserSerializer(serializers.ModelSerializer):
+class BlankToNullMixin:
+    """Пустые строки в указанных полях превращаем в None до валидации DRF."""
+    blank_to_null_fields = ()
+
+    def to_internal_value(self, data):
+        if hasattr(data, 'copy'):
+            data = data.copy()
+        else:
+            data = dict(data)
+        for field in getattr(self, 'blank_to_null_fields', ()):
+            if data.get(field) == '':
+                data[field] = None
+        return super().to_internal_value(data)
+
+
+class UserSerializer(BlankToNullMixin, serializers.ModelSerializer):
     is_superuser = serializers.BooleanField(default=False)
+    blank_to_null_fields = ('phone_number', 'email', 'deleted_at')
 
     class Meta:
         model = User
@@ -41,8 +57,8 @@ class UserSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         is_superuser = validated_data.pop('is_superuser', False)
         password = validated_data.pop('password')
-        email = validated_data.pop('email', None)
-        phone_number = validated_data.pop('phone_number', None)
+        email = validated_data.pop('email', None) or None
+        phone_number = validated_data.pop('phone_number', None) or None
 
         if is_superuser:
             user = User.objects.create_superuser(
@@ -204,12 +220,16 @@ class PerformanceCastSerializer(serializers.ModelSerializer):
         return attrs
 
 
-class PerfomanceSerializer(serializers.ModelSerializer):
+class PerfomanceSerializer(BlankToNullMixin, serializers.ModelSerializer):
     afisha = serializers.BooleanField(default=True)
     shows = PerformanceShowSerializer(many=True, required=False)
     cast = PerformanceCastSerializer(many=True, required=False, source='cast_members')
     # Имя режиссёра видно всегда (в т.ч. когда спектакль в "Афише").
     director_name = serializers.SerializerMethodField()
+    blank_to_null_fields = (
+        'duration', 'premiere_date', 'ticket_url', 'performances_image',
+        'deleted_at', 'director', 'production_year',
+    )
 
     class Meta:
         model = Perfomances
@@ -289,12 +309,13 @@ class PerfomanceSerializer(serializers.ModelSerializer):
         return instance
 
 
-class ActorsSerializer(serializers.ModelSerializer):
+class ActorsSerializer(BlankToNullMixin, serializers.ModelSerializer):
     deleted_at = serializers.DateTimeField(required=False, allow_null=True, default=None)
     # Вычисляемые поля: стаж в студии считается из joined_at/left_at.
     time_in_theatre = serializers.SerializerMethodField()
     is_active = serializers.SerializerMethodField()
     role_label = serializers.SerializerMethodField()
+    blank_to_null_fields = ('joined_at', 'left_at', 'deleted_at', 'gender_override')
 
     class Meta:
         model = Actors
@@ -356,15 +377,18 @@ class DirectorsSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class NewsSerializer(serializers.ModelSerializer):
+class NewsSerializer(BlankToNullMixin, serializers.ModelSerializer):
     is_published = serializers.BooleanField(default=False)
+    blank_to_null_fields = ('date_publish', 'deleted_at')
 
     class Meta:
         model = News
         fields = '__all__'
 
 
-class ArchiveSerializer(serializers.ModelSerializer):
+class ArchiveSerializer(BlankToNullMixin, serializers.ModelSerializer):
+    blank_to_null_fields = ('premiere_date', 'deleted_at', 'age_limit', 'archive_image')
+
     class Meta:
         model = Archive
         fields = '__all__'

--- a/backend/app/my_app1/tests.py
+++ b/backend/app/my_app1/tests.py
@@ -773,3 +773,47 @@ class ReturnToAfishaTests(TestCase):
         promote_past_performances()
         perf.refresh_from_db()
         self.assertTrue(perf.afisha)
+
+
+class BlankOptionalFieldsCreateTests(TestCase):
+    """Пустые строки в опциональных полях не должны ломать create."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = User.objects.create(
+            email='blank-admin@test.com', is_superuser=True, is_staff=True,
+            phone_number='+7-111-111-11-11', profile_photo='',
+        )
+        self.client.force_authenticate(user=self.admin)
+
+    def test_news_create_with_empty_date_publish(self):
+        resp = self.client.post('/news/', {
+            'title': 'Новость без даты',
+            'description': 'Описание новости достаточно длинное',
+            'date_publish': '',
+            'is_published': False,
+            'images_list': [],
+            'image_url': '',
+        }, format='json')
+        self.assertEqual(resp.status_code, 201, resp.data)
+        self.assertIsNone(resp.data.get('date_publish'))
+
+    def test_users_create_with_empty_phone_twice(self):
+        r1 = self.client.post('/users/', {
+            'email': 'u1@test.com',
+            'password': 'Teatr2026!',
+            'phone_number': '',
+            'is_superuser': False,
+            'profile_photo': '',
+        }, format='json')
+        self.assertEqual(r1.status_code, 201, r1.data)
+        r2 = self.client.post('/users/', {
+            'email': 'u2@test.com',
+            'password': 'Teatr2026!',
+            'phone_number': '',
+            'is_superuser': False,
+            'profile_photo': '',
+        }, format='json')
+        self.assertEqual(r2.status_code, 201, r2.data)
+        self.assertIsNone(User.objects.get(email='u1@test.com').phone_number)
+        self.assertIsNone(User.objects.get(email='u2@test.com').phone_number)

--- a/backend/app/my_app1/views.py
+++ b/backend/app/my_app1/views.py
@@ -54,6 +54,14 @@ class UserList(APIView):
         serializer = self.serializer_class(users, many=True)
         return Response(serializer.data)
 
+    @swagger_auto_schema(request_body=UserSerializer)
+    def post(self, request, format=None):
+        serializer = self.serializer_class(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
 
 class UserListAdmin(APIView):
     model_class = User

--- a/frontend/antrakt/src/pages/admin/forms/ActorForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/ActorForm.tsx
@@ -37,6 +37,7 @@ import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { chakra } from '@chakra-ui/react';
 import { API_URL } from '../../../config';
+import { emptyStringsToNull } from '../../../utils/adminPayload';
 import {
     ActorGender,
     getActorRoleLabel,
@@ -187,10 +188,15 @@ export const ActorForm: React.FC<{
         }));
     };
 
+    const buildActorPayload = () => emptyStringsToNull(
+        { ...currentActor } as Record<string, unknown>,
+        ['joined_at', 'left_at', 'deleted_at', 'gender_override'],
+    );
+
     const handleCreateActor = async () => {
         setIsSubmitting(true);
         try {
-            const response = await axios.post(`${API_URL}/actors/`, currentActor);
+            await axios.post(`${API_URL}/actors/`, buildActorPayload());
             toast({
                 title: 'Успех!',
                 description: 'Актёр успешно добавлен',
@@ -218,7 +224,7 @@ export const ActorForm: React.FC<{
 
         setIsSubmitting(true);
         try {
-            await axios.put(`${API_URL}/actor${currentActor.id}/`, currentActor);
+            await axios.put(`${API_URL}/actor${currentActor.id}/`, buildActorPayload());
             toast({
                 title: 'Успех!',
                 description: 'Актёр успешно обновлён',

--- a/frontend/antrakt/src/pages/admin/forms/ArchiveForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/ArchiveForm.tsx
@@ -39,6 +39,7 @@ import { chakra, useToast } from '@chakra-ui/react';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { API_URL } from '../../../config';
+import { emptyStringsToNull } from '../../../utils/adminPayload';
 
 const MotionButton = motion(Button);
 const MotionBox = motion(Box);
@@ -136,7 +137,11 @@ export const ArchiveForm: React.FC<{
                 ? `${API_URL}/archive${currentArchive.id}/`
                 : `${API_URL}/archive/`;
 
-            await axios[method](url, currentArchive);
+            const payload = emptyStringsToNull(
+                { ...currentArchive } as Record<string, unknown>,
+                ['premiere_date', 'age_limit', 'archive_image', 'deleted_at'],
+            );
+            await axios[method](url, payload);
 
             toast({
                 title: 'Успех',

--- a/frontend/antrakt/src/pages/admin/forms/NewsForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/NewsForm.tsx
@@ -40,6 +40,7 @@ import { chakra, useToast } from '@chakra-ui/react';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { API_URL } from '../../../config';
+import { emptyStringsToNull } from '../../../utils/adminPayload';
 
 const MotionButton = motion(Button);
 const MotionBox = motion(Box);
@@ -74,7 +75,7 @@ export const NewsForm: React.FC<{
         is_published: false,
         deleted_at: null,
         images_list: [],
-        date_publish: '' // Инициализация поля даты
+        date_publish: undefined,
     });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isGalleryUploading, setIsGalleryUploading] = useState(false);
@@ -133,10 +134,15 @@ export const NewsForm: React.FC<{
         }));
     };
 
+    const buildNewsPayload = () => emptyStringsToNull(
+        { ...currentNews } as Record<string, unknown>,
+        ['date_publish', 'deleted_at'],
+    );
+
     const handleCreateNews = async () => {
         setIsSubmitting(true);
         try {
-            await axios.post(`${API_URL}/news/`, currentNews);
+            await axios.post(`${API_URL}/news/`, buildNewsPayload());
             toast({
                 title: 'Успешно',
                 description: 'Новость создана',
@@ -164,7 +170,7 @@ export const NewsForm: React.FC<{
 
         setIsSubmitting(true);
         try {
-            await axios.put(`${API_URL}/news${currentNews.id}/`, currentNews);
+            await axios.put(`${API_URL}/news${currentNews.id}/`, buildNewsPayload());
             toast({
                 title: 'Успешно',
                 description: 'Новость обновлена',

--- a/frontend/antrakt/src/pages/admin/forms/PerformancesForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/PerformancesForm.tsx
@@ -48,6 +48,7 @@ import { chakra, useToast } from '@chakra-ui/react';
 import ImageUpload from '../../../components/ImageUpload';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { API_URL } from '../../../config';
+import { emptyStringsToNull } from '../../../utils/adminPayload';
 
 const MotionButton = motion(Button);
 const MotionTag = motion(Tag);
@@ -375,10 +376,23 @@ export const PerformanceForm: React.FC<{
         }));
     };
 
+    const buildPerformancePayload = () => emptyStringsToNull(
+        { ...currentPerformance } as Record<string, unknown>,
+        [
+            'duration',
+            'premiere_date',
+            'ticket_url',
+            'performances_image',
+            'deleted_at',
+            'director',
+            'production_year',
+        ],
+    );
+
     const handleCreatePerformance = async () => {
         setIsSubmitting(true);
         try {
-            await axios.post(`${API_URL}/perfomances/`, currentPerformance);
+            await axios.post(`${API_URL}/perfomances/`, buildPerformancePayload());
             toast({
                 title: 'Успех!',
                 description: 'Спектакль успешно добавлен',
@@ -406,7 +420,7 @@ export const PerformanceForm: React.FC<{
 
         setIsSubmitting(true);
         try {
-            await axios.put(`${API_URL}/perfomance${currentPerformance.id}/`, currentPerformance);
+            await axios.put(`${API_URL}/perfomance${currentPerformance.id}/`, buildPerformancePayload());
             toast({
                 title: 'Успех!',
                 description: 'Спектакль успешно обновлён',

--- a/frontend/antrakt/src/pages/admin/forms/UsersForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/UsersForm.tsx
@@ -21,6 +21,7 @@ import { FaTimes, FaSave } from 'react-icons/fa';
 import axios from 'axios';
 import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { API_URL } from '../../../config';
+import { emptyStringsToNull } from '../../../utils/adminPayload';
 
 const CFaTimes = chakra(FaTimes as any);
 const CFaSave = chakra(FaSave as any);
@@ -117,11 +118,11 @@ export const UserForm: React.FC<UserFormProps> = ({
 
         setIsSubmitting(true);
         try {
-            const userData: Partial<User> = {
+            const userData: Partial<User> = emptyStringsToNull({
                 email: user.email,
                 phone_number: user.phone_number,
                 is_superuser: user.is_superuser
-            };
+            } as Record<string, unknown>, ['email', 'phone_number']) as Partial<User>;
 
             // Добавляем пароль только если он был введён
             if (user.password) {

--- a/frontend/antrakt/src/utils/adminPayload.ts
+++ b/frontend/antrakt/src/utils/adminPayload.ts
@@ -1,0 +1,17 @@
+/**
+ * Перед отправкой в API: пустые строки в опциональных полях → null.
+ * Иначе DRF DateField/TimeField отклоняют '' («Date has wrong format»),
+ * а unique CharField (phone_number) ломается на повторном ''.
+ */
+export function emptyStringsToNull<T extends Record<string, unknown>>(
+    data: T,
+    fields: (keyof T)[],
+): T {
+    const next = { ...data };
+    for (const field of fields) {
+        if (next[field] === '') {
+            (next as Record<string, unknown>)[field as string] = null;
+        }
+    }
+    return next;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Reviewed all admin `RequiredFieldsHint` lists against models/serializers. The listed required fields were already correct; creates failed because optional fields were sent as empty strings (`''`), which DRF/DB reject.

### Fixes
- **News:** empty `date_publish` → `null` (was rejecting create with only title+description).
- **Users:** empty `phone_number` → `null` (unique constraint); also added missing `POST /users/` so admin user create works.
- **Performances / Archive / Actors:** same blank→null sanitization for optional dates/times/FKs.
- Backend `BlankToNullMixin` + frontend `emptyStringsToNull` helper.

### Hints unchanged (already accurate)
- Achievement: Текст достижения
- Actor: Имя и фамилия, Любимая цитата, Автор цитаты
- Archive: Название, Описание
- Director: Имя, Описание
- News: Заголовок, Описание
- Performance: Название, Автор, Жанр, Возрастное ограничение, Описание
- Users: Email, Пароль

## Test plan
- [ ] Create news with only title+description (no date) → succeeds.
- [ ] Create two admin users with email+password and empty phone → both succeed.
- [ ] Create performance/actor/archive filling only listed required fields → succeeds.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

