### PR TITLE
Favicon cache, коллектив режиссёра и плашки в админке

### DIFF
--- a/frontend/antrakt/nginx.conf
+++ b/frontend/antrakt/nginx.conf
@@ -10,6 +10,13 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Иконки сайта не кэшируем надолго — иначе после деплоя остаётся старый React favicon.
+    location ~* ^/(favicon\.ico|favicon-[0-9]+\.png|logo192\.png|logo512\.png|manifest\.json)$ {
+        expires -1;
+        add_header Cache-Control "no-cache, must-revalidate";
+        try_files $uri =404;
+    }
+
     # Долгое кэширование статических ассетов (у них хэш в имени).
     location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|webp|woff2?)$ {
         expires 30d;

--- a/frontend/antrakt/public/index.html
+++ b/frontend/antrakt/public/index.html
@@ -2,17 +2,17 @@
 <html lang="ru">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16.png" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico?v=3" />
+    <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32.png?v=3" />
+    <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16.png?v=3" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="Норильский народный театр — официальный сайт"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png?v=3" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json?v=3" />
     <title>Норильский народный театр</title>
   </head>
   <body>

--- a/frontend/antrakt/src/pages/admin/forms/DirectorForm.tsx
+++ b/frontend/antrakt/src/pages/admin/forms/DirectorForm.tsx
@@ -9,10 +9,8 @@ import {
     Textarea,
     Text,
     Grid,
-    Wrap,
-    Tag,
-    TagLabel,
-    TagCloseButton,
+    Box,
+    IconButton,
     Modal,
     ModalOverlay,
     ModalContent,
@@ -39,7 +37,7 @@ import RequiredFieldsHint from '../../../components/admin/RequiredFieldsHint';
 import { API_URL } from '../../../config';
 
 const MotionButton = motion(Button);
-const MotionTag = motion(Tag);
+const MotionBox = motion(Box);
 const CFaPlus = chakra(FaPlus as any);
 const CFaUser = chakra(FaUser as any);
 const CFaUsers = chakra(FaUsers as any);
@@ -161,6 +159,33 @@ export const DirectorForm: React.FC<{
             team_name: teams,
             years
         }));
+    };
+
+    const handlePerfomanceFieldChange = (
+        index: number,
+        field: 'title' | 'team' | 'year',
+        value: string
+    ) => {
+        setCurrentDirector(prev => {
+            const perfomances = [...(prev.perfomances || [])];
+            const teams = [...(prev.team_name || [])];
+            const years = [...(prev.years || [])];
+
+            while (perfomances.length <= index) perfomances.push('');
+            while (teams.length <= index) teams.push('');
+            while (years.length <= index) years.push(0);
+
+            if (field === 'title') {
+                perfomances[index] = value;
+            } else if (field === 'team') {
+                teams[index] = value;
+            } else {
+                const parsed = parseInt(value, 10);
+                years[index] = Number.isNaN(parsed) ? 0 : parsed;
+            }
+
+            return { ...prev, perfomances, team_name: teams, years };
+        });
     };
 
     const handleImageUpload = (imageUrl: string) => {
@@ -329,42 +354,86 @@ export const DirectorForm: React.FC<{
                             Добавить спектакль
                         </Button>
 
-                        <Wrap spacing={2} minH="50px" mb={4}>
+                        <VStack spacing={2} align="stretch" mb={4} maxH="420px" overflowY="auto">
                             <AnimatePresence>
                                 {currentDirector.perfomances?.map((perfomance, index) => (
-                                    <MotionTag
-                                        key={index}
-                                        initial={{ opacity: 0, scale: 0.8 }}
-                                        animate={{ opacity: 1, scale: 1 }}
-                                        exit={{ opacity: 0, scale: 0.8 }}
-                                        size="md"
-                                        variant="solid"
-                                        bg="#444444"
+                                    <MotionBox
+                                        key={`perf-${index}`}
+                                        initial={{ opacity: 0, y: 6 }}
+                                        animate={{ opacity: 1, y: 0 }}
+                                        exit={{ opacity: 0, y: -6 }}
+                                        p={3}
+                                        bg="#333333"
                                         borderRadius="md"
-                                        px={3}
-                                        py={2}
-                                        h="auto"
-                                        whiteSpace="normal"
-                                        maxW={{ base: '100%', md: '360px' }}
+                                        border="1px solid"
+                                        borderColor="#444444"
                                     >
-                                        <TagLabel
-                                            maxW="100%"
-                                            whiteSpace="normal"
-                                            overflow="visible"
-                                            textOverflow="clip"
-                                            lineHeight="1.3"
-                                            overflowWrap="anywhere"
-                                            wordBreak="break-word"
-                                        >
-                                            {perfomance}
-                                            {currentDirector.team_name?.[index] && ` (${currentDirector.team_name[index]})`}
-                                            {currentDirector.years?.[index] && `, ${currentDirector.years[index]} год`}
-                                        </TagLabel>
-                                        <TagCloseButton onClick={() => handleRemovePerfomance(index)} />
-                                    </MotionTag>
+                                        <Flex align="flex-start" gap={2}>
+                                            <VStack flex="1" minW={0} spacing={2} align="stretch">
+                                                <FormControl>
+                                                    <FormLabel fontSize="xs" mb={1} color="#AAAAAA">
+                                                        Название
+                                                    </FormLabel>
+                                                    <Input
+                                                        size="sm"
+                                                        value={perfomance}
+                                                        onChange={(e) =>
+                                                            handlePerfomanceFieldChange(index, 'title', e.target.value)
+                                                        }
+                                                        bg="#2a2a2a"
+                                                        borderColor="#555555"
+                                                        _hover={{ borderColor: '#666666' }}
+                                                        whiteSpace="normal"
+                                                    />
+                                                </FormControl>
+                                                <FormControl>
+                                                    <FormLabel fontSize="xs" mb={1} color="#AAAAAA">
+                                                        Коллектив
+                                                    </FormLabel>
+                                                    <Input
+                                                        size="sm"
+                                                        value={currentDirector.team_name?.[index] || ''}
+                                                        onChange={(e) =>
+                                                            handlePerfomanceFieldChange(index, 'team', e.target.value)
+                                                        }
+                                                        bg="#2a2a2a"
+                                                        borderColor="#555555"
+                                                        _hover={{ borderColor: '#666666' }}
+                                                        placeholder='Например: Труппа…/Образцовый коллектив…'
+                                                    />
+                                                </FormControl>
+                                                <FormControl maxW="140px">
+                                                    <FormLabel fontSize="xs" mb={1} color="#AAAAAA">
+                                                        Год
+                                                    </FormLabel>
+                                                    <Input
+                                                        size="sm"
+                                                        type="number"
+                                                        value={currentDirector.years?.[index] || ''}
+                                                        onChange={(e) =>
+                                                            handlePerfomanceFieldChange(index, 'year', e.target.value)
+                                                        }
+                                                        bg="#2a2a2a"
+                                                        borderColor="#555555"
+                                                        _hover={{ borderColor: '#666666' }}
+                                                    />
+                                                </FormControl>
+                                            </VStack>
+                                            <IconButton
+                                                aria-label="Удалить спектакль"
+                                                icon={<CFaTimes />}
+                                                size="sm"
+                                                variant="ghost"
+                                                colorScheme="red"
+                                                flexShrink={0}
+                                                mt={6}
+                                                onClick={() => handleRemovePerfomance(index)}
+                                            />
+                                        </Flex>
+                                    </MotionBox>
                                 ))}
                             </AnimatePresence>
-                        </Wrap>
+                        </VStack>
                     </FormControl>
                 </VStack>
             </Grid>

--- a/frontend/antrakt/src/pages/cards/DirectorDetail.tsx
+++ b/frontend/antrakt/src/pages/cards/DirectorDetail.tsx
@@ -279,7 +279,7 @@ const DirectorDetail: React.FC = () => {
                                             <CFaTheaterMasks mr={2} color="#d9d9d9" />
                                             Поставленные спектакли
                                         </Heading>
-                                        <Grid templateColumns="repeat(auto-fill, minmax(220px, 1fr))" gap={4}>
+                                        <Grid templateColumns="repeat(auto-fill, minmax(260px, 1fr))" gap={4}>
                                             {director.perfomances.map((perfomance, idx) => (
                                                 <MotionBox
                                                     key={idx}
@@ -292,7 +292,7 @@ const DirectorDetail: React.FC = () => {
                                                     bg="linear-gradient(135deg, rgba(20, 20, 20, 0.9), rgba(255, 255, 255, 0.05))"
                                                     cursor="pointer"
                                                     whileHover={{
-                                                        scale: 1.05,
+                                                        scale: 1.03,
                                                         boxShadow: "0 10px 25px rgba(255, 255, 255, 0.12)",
                                                         transition: { duration: 0.3 }
                                                     }}
@@ -308,26 +308,29 @@ const DirectorDetail: React.FC = () => {
                                                         color="white"
                                                         fontSize="sm"
                                                         whiteSpace="normal"
-                                                        overflowWrap="anywhere"
                                                         wordBreak="break-word"
                                                     >
                                                         {perfomance}
                                                     </Text>
-                                                    {director.years?.[idx] && (
+                                                    {director.years?.[idx] != null && director.years[idx] !== 0 && (
                                                         <Text fontSize="xs" color="gray.400" mt={1}>
                                                             Год: {director.years[idx]}
                                                         </Text>
                                                     )}
-                                                    {director.team_name?.[idx] && (
+                                                    {!!director.team_name?.[idx] && (
                                                         <Text
+                                                            as="div"
                                                             fontSize="xs"
                                                             color="gray.400"
                                                             mt={1}
-                                                            whiteSpace="normal"
-                                                            overflowWrap="anywhere"
+                                                            whiteSpace="pre-wrap"
                                                             wordBreak="break-word"
+                                                            overflow="visible"
                                                         >
-                                                            Коллектив: {director.team_name[idx]}
+                                                            Коллектив:{' '}
+                                                            <Text as="span" color="gray.300">
+                                                                {String(director.team_name[idx])}
+                                                            </Text>
                                                         </Text>
                                                     )}
                                                 </MotionBox>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

1. **Favicon всё ещё React** — в `nginx.conf` иконки кэшировались на 30 дней, поэтому после деплоя браузер держал старый файл. Теперь для `favicon*` / `logo192|512` / `manifest` стоит `no-cache`, в `index.html` добавлен `?v=3`. **Нужен rebuild фронтенда** и жёсткое обновление вкладки (Ctrl+F5).
2. **Коллектив на плашке режиссёра** — в админке плашки-теги обрезали текст (из‑за этого часть после `/` не было видно). Список спектаклей переделан на нормальные строки с полным текстом и возможностью править коллектив прямо в форме; на публичной карточке усилен перенос длинного текста.
3. **Кривые плашки в админке** — Chakra `Tag` с ellipsis заменены на читаемые блоки (название / коллектив / год).

## После деплоя

```bash
docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build frontend
```

Затем в админке у «Дюймовочка» проверьте поле «Коллектив» целиком и сохраните режиссёра.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

