### PR TITLE
Динамический sitemap.xml и robots.txt

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -8,6 +8,8 @@
 
 # --- Домен (без схемы). Нужны A-записи: DOMAIN, api.DOMAIN, s3.DOMAIN ---
 DOMAIN=nskfolktheatre.ru
+# Публичный URL сайта (для sitemap.xml). Обычно https://DOMAIN
+# FRONTEND_BASE_URL=https://nskfolktheatre.ru
 
 # --- Django ---
 # Сгенерируйте длинный случайный ключ, например:

--- a/Caddyfile
+++ b/Caddyfile
@@ -5,7 +5,24 @@
 
 {$DOMAIN} {
 	encode gzip
-	reverse_proxy frontend:80
+
+	# Sitemap и robots отдаёт Django (динамически), Host — api.* (ALLOWED_HOSTS).
+	handle /sitemap.xml {
+		reverse_proxy backend:8000 {
+			header_up Host api.{$DOMAIN}
+			header_up X-Forwarded-Proto {scheme}
+		}
+	}
+	handle /robots.txt {
+		reverse_proxy backend:8000 {
+			header_up Host api.{$DOMAIN}
+			header_up X-Forwarded-Proto {scheme}
+		}
+	}
+
+	handle {
+		reverse_proxy frontend:80
+	}
 }
 
 api.{$DOMAIN} {

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -6,7 +6,9 @@
 Публичные адреса после запуска:
 - `https://<DOMAIN>` — сайт (React);
 - `https://api.<DOMAIN>` — backend (Django/DRF), админка Django: `https://api.<DOMAIN>/admin/`;
-- `https://s3.<DOMAIN>` — изображения (MinIO).
+- `https://s3.<DOMAIN>` — изображения (MinIO);
+- `https://<DOMAIN>/sitemap.xml` — динамическая карта сайта (Django через Caddy);
+- `https://<DOMAIN>/robots.txt` — robots с ссылкой на sitemap.
 
 ---
 

--- a/backend/app/app/settings.py
+++ b/backend/app/app/settings.py
@@ -130,6 +130,10 @@ SIMPLE_JWT = {
     'SLIDING_TOKEN_REFRESH_LIFETIME': None,
 }
 
+# Публичный URL фронтенда (без завершающего слэша) — для sitemap.xml / robots.txt.
+# В проде задаётся через FRONTEND_BASE_URL=https://ваш-домен.
+FRONTEND_BASE_URL = config('FRONTEND_BASE_URL', default='http://localhost:3000')
+
 # CORS/CSRF: в dev разрешаем всё; в проде выключите CORS_ALLOW_ALL_ORIGINS и
 # перечислите домены фронтенда в CORS_ALLOWED_ORIGINS / CSRF_TRUSTED_ORIGINS.
 CORS_ALLOW_ALL_ORIGINS = config('CORS_ALLOW_ALL_ORIGINS', default=True, cast=bool)

--- a/backend/app/app/urls.py
+++ b/backend/app/app/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from my_app1 import views
+from my_app1.sitemap import RobotsTxtView, SitemapView
 from drf_yasg import openapi
 from django.contrib import admin
 from django.http import JsonResponse
@@ -45,6 +46,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api-auth/', include('rest_framework.urls')),
     path('health/', health_check, name='health-check'),
+    path('sitemap.xml', SitemapView.as_view(), name='sitemap'),
+    path('robots.txt', RobotsTxtView.as_view(), name='robots-txt'),
     path('users/', views.UserList.as_view(), name='user-list'),
     path('user<int:id>/', views.UserDetail.as_view(), name='user'),
     path('users-admin/', views.UserListAdmin.as_view(), name='user-list-admin'),

--- a/backend/app/my_app1/sitemap.py
+++ b/backend/app/my_app1/sitemap.py
@@ -1,0 +1,172 @@
+"""Динамический sitemap.xml и robots.txt для публичного сайта (фронтенд)."""
+
+from xml.sax.saxutils import escape
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.utils import timezone
+from rest_framework.views import APIView
+
+from .models import (
+    Achievements,
+    Actors,
+    Archive,
+    DirectorsTheatre,
+    News,
+    Perfomances,
+)
+
+
+def _site_base() -> str:
+    """Базовый URL публичного сайта без завершающего слэша."""
+    base = (getattr(settings, 'FRONTEND_BASE_URL', '') or '').strip().rstrip('/')
+    if base:
+        return base
+    # Dev-fallback, если FRONTEND_BASE_URL не задан.
+    return 'http://localhost:3000'
+
+
+def _fmt_lastmod(value) -> str | None:
+    if value is None:
+        return None
+    if timezone.is_aware(value):
+        value = timezone.localtime(value)
+    try:
+        return value.date().isoformat()
+    except AttributeError:
+        return value.isoformat()[:10]
+
+
+def _collect_urls():
+    """Собрать публичные URL фронтенда для sitemap."""
+    base = _site_base()
+    urls = []
+
+    def add(path: str, lastmod=None, changefreq='weekly', priority='0.5'):
+        loc = f'{base}{path}'
+        urls.append({
+            'loc': loc,
+            'lastmod': _fmt_lastmod(lastmod),
+            'changefreq': changefreq,
+            'priority': priority,
+        })
+
+    # Статические разделы
+    add('/', changefreq='daily', priority='1.0')
+    add('/afisha', changefreq='daily', priority='0.9')
+    add('/performances', changefreq='weekly', priority='0.8')
+    add('/team', changefreq='weekly', priority='0.8')
+    add('/news', changefreq='daily', priority='0.8')
+    add('/projects', changefreq='weekly', priority='0.7')
+    add('/achievements', changefreq='monthly', priority='0.6')
+    add('/about', changefreq='monthly', priority='0.6')
+
+    for perf in Perfomances.objects.filter(deleted_at=None).only(
+        'id', 'updated_at', 'created_at', 'premiere_date'
+    ):
+        add(
+            f'/performance/{perf.id}',
+            lastmod=perf.updated_at or perf.premiere_date or perf.created_at,
+            changefreq='weekly',
+            priority='0.7',
+        )
+
+    for actor in Actors.objects.filter(deleted_at=None).only(
+        'id', 'updated_at', 'created_at'
+    ):
+        add(
+            f'/actor/{actor.id}',
+            lastmod=actor.updated_at or actor.created_at,
+            changefreq='monthly',
+            priority='0.6',
+        )
+
+    for director in DirectorsTheatre.objects.filter(deleted_at=None).only(
+        'id', 'updated_at', 'created_at'
+    ):
+        add(
+            f'/director/{director.id}',
+            lastmod=director.updated_at or director.created_at,
+            changefreq='monthly',
+            priority='0.6',
+        )
+
+    for item in News.objects.filter(deleted_at=None, is_published=True).only(
+        'id', 'updated_at', 'date_publish', 'created_at'
+    ):
+        add(
+            f'/news/{item.id}',
+            lastmod=item.updated_at or item.date_publish or item.created_at,
+            changefreq='weekly',
+            priority='0.7',
+        )
+
+    for item in Archive.objects.filter(deleted_at=None).only(
+        'id', 'updated_at', 'created_at', 'premiere_date'
+    ):
+        add(
+            f'/projects/{item.id}',
+            lastmod=item.updated_at or item.premiere_date or item.created_at,
+            changefreq='monthly',
+            priority='0.6',
+        )
+
+    for item in Achievements.objects.filter(deleted_at=None).only(
+        'id', 'updated_at', 'created_at'
+    ):
+        add(
+            f'/achievement/{item.id}',
+            lastmod=item.updated_at or item.created_at,
+            changefreq='monthly',
+            priority='0.5',
+        )
+
+    return urls
+
+
+def _render_sitemap(urls) -> str:
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ]
+    for entry in urls:
+        lines.append('  <url>')
+        lines.append(f'    <loc>{escape(entry["loc"])}</loc>')
+        if entry.get('lastmod'):
+            lines.append(f'    <lastmod>{entry["lastmod"]}</lastmod>')
+        if entry.get('changefreq'):
+            lines.append(f'    <changefreq>{entry["changefreq"]}</changefreq>')
+        if entry.get('priority'):
+            lines.append(f'    <priority>{entry["priority"]}</priority>')
+        lines.append('  </url>')
+    lines.append('</urlset>')
+    return '\n'.join(lines) + '\n'
+
+
+class SitemapView(APIView):
+    """GET /sitemap.xml — карта сайта для поисковиков."""
+
+    authentication_classes = []
+    permission_classes = []
+
+    def get(self, request, format=None):
+        xml = _render_sitemap(_collect_urls())
+        return HttpResponse(xml, content_type='application/xml; charset=utf-8')
+
+
+class RobotsTxtView(APIView):
+    """GET /robots.txt — указывает на sitemap на основном домене."""
+
+    authentication_classes = []
+    permission_classes = []
+
+    def get(self, request, format=None):
+        base = _site_base()
+        body = (
+            'User-agent: *\n'
+            'Allow: /\n'
+            'Disallow: /admin\n'
+            'Disallow: /profile\n'
+            f'Sitemap: {base}/sitemap.xml\n'
+        )
+        return HttpResponse(body, content_type='text/plain; charset=utf-8')

--- a/backend/app/my_app1/tests.py
+++ b/backend/app/my_app1/tests.py
@@ -847,3 +847,53 @@ class BlankOptionalFieldsCreateTests(TestCase):
         self.assertEqual(r2.status_code, 201, r2.data)
         self.assertIsNone(User.objects.get(email='u1@test.com').phone_number)
         self.assertIsNone(User.objects.get(email='u2@test.com').phone_number)
+
+
+class SitemapTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.director = DirectorsTheatre.objects.create(name='Реж', description='о')
+        self.actor = Actors.objects.create(
+            name='Актёр', favorite_quote='q', author_quote='a', image_url='',
+        )
+        self.perf = Perfomances.objects.create(
+            title='Спектакль', author='А', genre='Драма', age_limit='12+',
+            description='о', afisha=False, director=self.director,
+        )
+        News.objects.create(
+            title='Новость', description='длинное описание новости',
+            is_published=True, image_url='',
+        )
+        News.objects.create(
+            title='Черновик', description='длинное описание черновика',
+            is_published=False, image_url='',
+        )
+        Archive.objects.create(
+            title='Проект', description='д', afisha=False, image_url='',
+        )
+
+    def test_sitemap_contains_public_urls(self):
+        resp = self.client.get('/sitemap.xml')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('application/xml', resp['Content-Type'])
+        body = resp.content.decode('utf-8')
+        self.assertIn('/performance/', body)
+        self.assertIn(f'/director/{self.director.id}', body)
+        self.assertIn(f'/actor/{self.actor.id}', body)
+        self.assertIn('/news/', body)
+        self.assertIn('/projects/', body)
+        self.assertIn('/afisha', body)
+        # Неопубликованные новости не попадают в sitemap как отдельная детальная
+        # страница только если is_published=True — черновик не должен быть в списке
+        # детальных URL (проверяем, что опубликованная есть).
+        published = News.objects.get(title='Новость')
+        self.assertIn(f'/news/{published.id}', body)
+        draft = News.objects.get(title='Черновик')
+        self.assertNotIn(f'/news/{draft.id}', body)
+
+    def test_robots_points_to_sitemap(self):
+        resp = self.client.get('/robots.txt')
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode('utf-8')
+        self.assertIn('Sitemap:', body)
+        self.assertIn('sitemap.xml', body)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,6 +78,8 @@ services:
       CORS_ALLOW_ALL_ORIGINS: "False"
       CORS_ALLOWED_ORIGINS: https://${DOMAIN}
       CSRF_TRUSTED_ORIGINS: https://${DOMAIN},https://api.${DOMAIN}
+      # Базовый URL сайта для sitemap.xml / robots.txt
+      FRONTEND_BASE_URL: https://${DOMAIN}
       PLACEHOLDER_IMAGE_URL: ${PLACEHOLDER_IMAGE_URL:-https://s3.${DOMAIN}/${MINIO_BUCKET_NAME:-antrakt-images}/zaglushka.jpg}
     depends_on:
       db:

--- a/frontend/antrakt/public/robots.txt
+++ b/frontend/antrakt/public/robots.txt
@@ -1,3 +1,7 @@
-# https://www.robotstxt.org/robotstxt.html
+# На проде /robots.txt отдаёт Django (см. Caddyfile → backend).
+# Этот файл используется только в локальной разработке (npm start).
 User-agent: *
-Disallow:
+Allow: /
+Disallow: /admin
+Disallow: /profile
+Sitemap: http://localhost:3000/sitemap.xml


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Динамический `sitemap.xml` генерируется Django из БД (разделы + спектакли, актёры, режиссёры, новости, проекты, достижения).

На основном домене Caddy проксирует:
- `https://<DOMAIN>/sitemap.xml` → backend
- `https://<DOMAIN>/robots.txt` → backend (со ссылкой на sitemap)

В `docker-compose.prod.yml` добавлен `FRONTEND_BASE_URL=https://${DOMAIN}`.

## После деплоя

```bash
git pull
docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build backend caddy
```

Проверка: откройте `https://ваш-домен/sitemap.xml` — должен быть XML со списком URL. В Яндекс.Вебмастере укажите этот адрес.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

