### PR TITLE
Fix 500 на /sitemap.xml (DateField lastmod)

### DIFF
--- a/backend/app/my_app1/sitemap.py
+++ b/backend/app/my_app1/sitemap.py
@@ -27,14 +27,15 @@ def _site_base() -> str:
 
 
 def _fmt_lastmod(value) -> str | None:
+    """Дата lastmod для sitemap: datetime или date → YYYY-MM-DD."""
     if value is None:
         return None
-    if timezone.is_aware(value):
-        value = timezone.localtime(value)
-    try:
+    # DateField (premiere_date, date_publish) — не datetime, is_aware падает.
+    if hasattr(value, 'utcoffset'):
+        if timezone.is_aware(value):
+            value = timezone.localtime(value)
         return value.date().isoformat()
-    except AttributeError:
-        return value.isoformat()[:10]
+    return value.isoformat()[:10]
 
 
 def _collect_urls():

--- a/backend/app/my_app1/tests.py
+++ b/backend/app/my_app1/tests.py
@@ -897,3 +897,13 @@ class SitemapTests(TestCase):
         body = resp.content.decode('utf-8')
         self.assertIn('Sitemap:', body)
         self.assertIn('sitemap.xml', body)
+
+    def test_sitemap_handles_date_lastmod(self):
+        """premiere_date — DateField; раньше давал 500 через timezone.is_aware(date)."""
+        from datetime import date
+        self.perf.premiere_date = date(2024, 5, 1)
+        self.perf.updated_at = None
+        self.perf.save(update_fields=['premiere_date', 'updated_at'])
+        resp = self.client.get('/sitemap.xml')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('2024-05-01', resp.content.decode('utf-8'))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Причина 500

В `sitemap.xml` для `lastmod` вызывался `timezone.is_aware()` на поле типа **date** (`premiere_date` / `date_publish`). У `date` нет `utcoffset` → падение и Server Error (500).

## Исправление

Корректная обработка и `date`, и `datetime`.

После мержа:

```bash
git pull
docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build backend
```

Затем снова откройте `https://nskfolktheatre.ru/sitemap.xml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcf1ea9-da57-4fab-a2ca-bd2371e6d484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

